### PR TITLE
fix: move Grafana admin password to SealedSecret

### DIFF
--- a/infrastructure/controllers/grafana/configmap-helm-values.yaml
+++ b/infrastructure/controllers/grafana/configmap-helm-values.yaml
@@ -6,8 +6,6 @@ metadata:
   namespace: flux-system
 data:
   values.yaml: |
-    adminPassword: admin
-    
     persistence:
       enabled: true
       storageClassName: longhorn

--- a/infrastructure/controllers/grafana/helmrelease.yaml
+++ b/infrastructure/controllers/grafana/helmrelease.yaml
@@ -21,3 +21,7 @@ spec:
   - kind: ConfigMap
     name: grafana-helm-chart-value-overrides
     valuesKey: values.yaml
+  - kind: Secret
+    name: grafana-admin-credentials
+    valuesKey: adminPassword
+    targetPath: adminPassword

--- a/infrastructure/controllers/grafana/kustomization.yaml
+++ b/infrastructure/controllers/grafana/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - configmap-helm-values.yaml
+  - sealed-grafana-secrets.yaml

--- a/infrastructure/controllers/grafana/sealed-grafana-secrets.yaml
+++ b/infrastructure/controllers/grafana/sealed-grafana-secrets.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: grafana-admin-credentials
+  namespace: flux-system
+spec:
+  encryptedData:
+    adminPassword: AgAXB0C402q3vtX/sfqQsRw1VqLQQtfNI/IBEJY3y+RtSj/Noy9YzepZcF/hyDmxVdm4oGDxniaH+1tcR/H6UgIYfujt6yxZhqu8qmKqDXTO89YWcWz/Hk6AvFScFu3ZCZmXb+3fWQ3lxWErdkzd51jDZUf/NJ1yi2sTcQq+8MVPOsR/OXbFcnNqddJlwAlR3QaEuiYgNW7ewkPUe96xZv/XInd/RgdZoTrBs0LWewsh7L+bsl9xJWV4QVZFP+PzYECiMEHd3u+X4y68pj18PxMkJToA0I2BJGyvrDO7gD4P7iKAdkOZ906MHMYf181OyWcyvlGGYAHbCahUWlmz7C7i1sQvCOMc8xFhw/DZ1xpszyuGGv65EN3RdvUPCzLAagnCyI98uh4J7EHQND/nn5c3o7hsAoHRXPJ2YV2Jc4TrC2gI0nZ4qFI1J8xxsGgDAkzwS3zOOdMnGdsYJy83PNtNmhPfqKB5d7RhD8dWUCloowMtDbR26LfvuITfjSAsMruFUKhpO2GOi4Vddk8cTogpvAQicu6kwvTz2YMb/0+q6YLaG+KqJUAm+Y2Y3NBTYbTivJBEblugOx89OfKDA/C3CJsdOcFlkcGqLbsrtqpORkD1EhdS5qnQeOucwvHCoT9hepwepREr5xPqnoJHgf8alELgOLLl1xTDFAC8Rz95ed6z9Mqo4S2U+TV/W8E+UAFgfwudys5TgzDGbhR1z7xZoIizEQ9esSbx7cqehOX/Ww==
+  template:
+    metadata:
+      name: grafana-admin-credentials
+      namespace: flux-system


### PR DESCRIPTION
## Summary
- Removes the hardcoded `adminPassword: admin` from the Grafana ConfigMap (`configmap-helm-values.yaml`)
- Creates a SealedSecret (`sealed-grafana-secrets.yaml`) containing an encrypted, randomly generated admin password
- Updates the HelmRelease to inject the password from the SealedSecret via `valuesFrom` with `targetPath: adminPassword`
- Adds the SealedSecret to the Kustomization resources

## Motivation

The Grafana admin password was committed in plain text in `infrastructure/controllers/grafana/configmap-helm-values.yaml:9`. This exposed the credential to anyone with repo read access, and it persists in git history.

## Changes

| File | Change |
|---|---|
| `infrastructure/controllers/grafana/configmap-helm-values.yaml` | Removed `adminPassword: admin` |
| `infrastructure/controllers/grafana/helmrelease.yaml` | Added `valuesFrom` entry referencing the SealedSecret |
| `infrastructure/controllers/grafana/kustomization.yaml` | Added `sealed-grafana-secrets.yaml` to resources |
| `infrastructure/controllers/grafana/sealed-grafana-secrets.yaml` | **New** — SealedSecret with encrypted admin password |

## How it works

The Grafana Helm chart's `adminPassword` value is now sourced from a Secret (unsealed by the sealed-secrets controller) instead of the ConfigMap. The HelmRelease uses:

```yaml
valuesFrom:
- kind: Secret
  name: grafana-admin-credentials
  valuesKey: adminPassword
  targetPath: adminPassword
```

This follows the same pattern used by other apps in the repo (e.g., langfuse, umami).

## Post-merge action

After Flux reconciles, retrieve the new Grafana admin password:

```bash
kubectl get secret grafana-admin-credentials -n flux-system -o jsonpath='{.data.adminPassword}' | base64 -d
```

Closes #1