### PR TITLE
fix: disable public ingress for Loki

### DIFF
--- a/infrastructure/controllers/loki/configmap-helm-values.yaml
+++ b/infrastructure/controllers/loki/configmap-helm-values.yaml
@@ -76,14 +76,4 @@ data:
       enabled: true
       replicas: 1
       ingress:
-        enabled: true
-        ingressClassName: nginx
-        hosts:
-          - host: loki.yesidlopez.de
-            paths:
-              - path: /
-                pathType: Prefix
-        tls:
-          - secretName: loki-tls
-            hosts:
-              - loki.yesidlopez.de
+        enabled: false


### PR DESCRIPTION
## Summary
- Disables the public Ingress for Loki (`loki.yesidlopez.de`) which was exposed without authentication
- The gateway remains enabled for internal cluster access — Grafana reaches Loki via `http://loki-gateway.loki:80`
- For ad-hoc access, use `kubectl port-forward`

Closes #2