### PR TITLE
feat: add Flux Discord notifications for deployment failures

### DIFF
--- a/clusters/production/infrastructure.yaml
+++ b/clusters/production/infrastructure.yaml
@@ -31,4 +31,21 @@ spec:
     name: flux-system
   path: ./infrastructure/configs
   prune: true
-  wait: true 
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: notifications
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: infra-controllers
+  interval: 1h
+  retryInterval: 1m
+  timeout: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/production/notifications
+  prune: true

--- a/clusters/production/notifications/alert.yaml
+++ b/clusters/production/notifications/alert.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: on-call
+  namespace: flux-system
+spec:
+  providerRef:
+    name: discord
+  eventSeverity: error
+  eventSources:
+    - kind: Kustomization
+      name: '*'
+    - kind: HelmRelease
+      name: '*'
+    - kind: GitRepository
+      name: '*'
+    - kind: ImageUpdateAutomation
+      name: '*'

--- a/clusters/production/notifications/kustomization.yaml
+++ b/clusters/production/notifications/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - sealed-secret.yaml
+  - provider.yaml
+  - alert.yaml

--- a/clusters/production/notifications/provider.yaml
+++ b/clusters/production/notifications/provider.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: discord
+  namespace: flux-system
+spec:
+  type: discord
+  secretRef:
+    name: discord-webhook-url

--- a/clusters/production/notifications/sealed-secret.yaml
+++ b/clusters/production/notifications/sealed-secret.yaml
@@ -1,0 +1,31 @@
+---
+# To generate this sealed secret:
+#
+# 1. Create a Discord webhook URL in your server:
+#    Server Settings -> Integrations -> Webhooks -> New Webhook
+#    Copy the webhook URL.
+#
+# 2. Create the plain secret (do NOT commit this):
+#    kubectl create secret generic discord-webhook-url \
+#      --namespace flux-system \
+#      --from-literal=address=https://discord.com/api/webhooks/<id>/<token> \
+#      --dry-run=client -o yaml > /tmp/discord-secret.yaml
+#
+# 3. Seal it:
+#    make encrypt INPUT=/tmp/discord-secret.yaml OUTPUT=clusters/production/notifications/sealed-secret.yaml
+#
+# 4. Commit the sealed-secret.yaml (this file).
+#
+# Replace the placeholder below with the output of step 3.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: discord-webhook-url
+  namespace: flux-system
+spec:
+  encryptedData:
+    address: REPLACE_WITH_SEALED_VALUE
+  template:
+    metadata:
+      name: discord-webhook-url
+      namespace: flux-system

--- a/clusters/production/notifications/sealed-secret.yaml
+++ b/clusters/production/notifications/sealed-secret.yaml
@@ -1,22 +1,3 @@
----
-# To generate this sealed secret:
-#
-# 1. Create a Discord webhook URL in your server:
-#    Server Settings -> Integrations -> Webhooks -> New Webhook
-#    Copy the webhook URL.
-#
-# 2. Create the plain secret (do NOT commit this):
-#    kubectl create secret generic discord-webhook-url \
-#      --namespace flux-system \
-#      --from-literal=address=https://discord.com/api/webhooks/<id>/<token> \
-#      --dry-run=client -o yaml > /tmp/discord-secret.yaml
-#
-# 3. Seal it:
-#    make encrypt INPUT=/tmp/discord-secret.yaml OUTPUT=clusters/production/notifications/sealed-secret.yaml
-#
-# 4. Commit the sealed-secret.yaml (this file).
-#
-# Replace the placeholder below with the output of step 3.
 apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
@@ -24,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   encryptedData:
-    address: REPLACE_WITH_SEALED_VALUE
+    address: AgBwKxiIQvIimrEhs8s+Qjv79TJjcMJJ7K2me3yrQmCRCPFRaMUE5td5cn9aNurIzzMwneV4bpLh32knak26bhigX5M+hKVci2FGhGjjZwqWjBLzvKSngNbsB5m5aUpI71QxtKST504/aK+DC7Jo4qMBlWsvQExenDBeFBTZTkggO8MM0XP5qGbM6J33H2CxEqPlXBIzbSrStHXTjk/h5S57auyFve/prtjmwjW8mVPhAaO4Ca4egy8NY01KDowsoycaS9sRmbytSjKYwPMb/98Ctk3je4wHLutTzpukOjK0wdR0RU0IaaS40NV00X3wOlyx126M03NmQqIc/BuLBeJRk7OH6j68/C0AMao+EYXDLnxOF/+pL8bVMK6j1penffjEY2zg6AkjbfgrrA57V1EI4uPx3G676FgwrdpccM5YIRHW9lZ/EIIiutGlOFM6oAjO8MXYcMlzO0AF8uQzRCNrCnV/W6uEhzVIEIY2MW2Z6CTY+tVsJX69G/651DHE7zi/dT4hpAkRl8zu9dIp/xFmC92lE+eAzZuwmXLRviFT5/OPVA/RjktJYVls5KWa20y0lGmHeRbKkTRrOVVlmN94Y65t6j/eBF04rbp8MRHugfHW/QhCUa4StHvBRaQeKmm/E6OCcNIxYzjaB+9/HPJWi3B/gVao7CHtx0ebaLFTXZG+BJjZz2LfGG6kApehUWCkmIndWTXlq3seyfxAvpM5IYHugXy2TS6jWX0jXWUfAMucvO/uXJM1OTqITZhxWCWZwNApMPOy6mrqCdP8cGu7iJOMiKAlfihvgSeT79xcHjjVOOtfwsFCfyIgNM8XSbZ3KfwcAOUKsHtVOTDRSEMwt9wtVU0Iqn0/
   template:
     metadata:
       name: discord-webhook-url


### PR DESCRIPTION
## Summary
- Adds a Flux `Provider` (Discord) and `Alert` that fires on any `error`-severity event
- Covers all `Kustomization`, `HelmRelease`, `GitRepository`, and `ImageUpdateAutomation` resources cluster-wide
- Adds a `notifications` Flux Kustomization in `infrastructure.yaml` that depends on `infra-controllers`

## What's included
- `clusters/production/notifications/provider.yaml` — Discord Provider referencing the webhook secret
- `clusters/production/notifications/alert.yaml` — Alert watching `*` for all four resource kinds at `error` severity
- `clusters/production/notifications/sealed-secret.yaml` — placeholder with step-by-step instructions to seal the real webhook URL
- `clusters/production/infrastructure.yaml` — new `notifications` Kustomization

## Before this is active
The `sealed-secret.yaml` currently has a placeholder value. Follow the instructions inside the file to:
1. Create a Discord webhook in your server (Settings → Integrations → Webhooks)
2. Run `kubectl create secret` + `make encrypt` to produce the sealed secret
3. Replace the placeholder in `sealed-secret.yaml` and push

Closes #14