### PR TITLE
Increase Grafana timeout and register Flux MCP server

### DIFF
--- a/.opencode/config.json
+++ b/.opencode/config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "flux-operator-mcp": {
+      "command": "flux-operator-mcp",
+      "args": [
+        "serve"
+      ],
+      "env": {
+        "KUBECONFIG": "/Users/yelopez/.kube/config"
+      }
+    }
+  }
+}

--- a/infrastructure/controllers/grafana/helmrelease.yaml
+++ b/infrastructure/controllers/grafana/helmrelease.yaml
@@ -15,6 +15,7 @@ spec:
         name: grafana
         namespace: flux-system
   interval: 5m0s
+  timeout: 10m0s
   releaseName: grafana
   targetNamespace: grafana
   valuesFrom:


### PR DESCRIPTION
## Summary
- add OpenCode MCP config so flux-operator-mcp starts with the CLI
- extend the Grafana HelmRelease timeout to 10m to stop stalled upgrades

## Testing
- not run (infrastructure change)