### PR TITLE
chore: migrate flux manifests to ga apis

### DIFF
--- a/apps/production/docker-registry/helmrelease.yaml
+++ b/apps/production/docker-registry/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: docker-registry

--- a/apps/production/docker-registry/helmrepository.yaml
+++ b/apps/production/docker-registry/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: twuni

--- a/apps/production/docker-registry/ui/helmrelease.yaml
+++ b/apps/production/docker-registry/ui/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: docker-registry-ui

--- a/apps/production/docker-registry/ui/helmrepository.yaml
+++ b/apps/production/docker-registry/ui/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: joxit

--- a/apps/production/gotenberg/helmrelease.yaml
+++ b/apps/production/gotenberg/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: gotenberg

--- a/apps/production/gotenberg/helmrepository.yaml
+++ b/apps/production/gotenberg/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: maikumori

--- a/apps/production/langfuse/helmrelease.yaml
+++ b/apps/production/langfuse/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: langfuse

--- a/apps/production/langfuse/helmrepository.yaml
+++ b/apps/production/langfuse/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: langfuse

--- a/apps/production/macondo/image-automation/imagepolicy.yaml
+++ b/apps/production/macondo/image-automation/imagepolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: macondo-prod

--- a/apps/production/macondo/image-automation/imagerepository.yaml
+++ b/apps/production/macondo/image-automation/imagerepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: macondo

--- a/apps/production/macondo/image-automation/imageupdateautomation.yaml
+++ b/apps/production/macondo/image-automation/imageupdateautomation.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: macondo-prod

--- a/apps/production/resumelo/dev/image-automation/imagepolicy.yaml
+++ b/apps/production/resumelo/dev/image-automation/imagepolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: resumelo-dev

--- a/apps/production/resumelo/dev/image-automation/imagerepository.yaml
+++ b/apps/production/resumelo/dev/image-automation/imagerepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: resumelo

--- a/apps/production/resumelo/dev/image-automation/imageupdateautomation.yaml
+++ b/apps/production/resumelo/dev/image-automation/imageupdateautomation.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: resumelo-dev

--- a/apps/production/resumelo/prod/image-automation/imagepolicy.yaml
+++ b/apps/production/resumelo/prod/image-automation/imagepolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImagePolicy
 metadata:
   name: resumelo-prod

--- a/apps/production/resumelo/prod/image-automation/imagerepository.yaml
+++ b/apps/production/resumelo/prod/image-automation/imagerepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageRepository
 metadata:
   name: resumelo

--- a/apps/production/resumelo/prod/image-automation/imageupdateautomation.yaml
+++ b/apps/production/resumelo/prod/image-automation/imageupdateautomation.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta2
+apiVersion: image.toolkit.fluxcd.io/v1
 kind: ImageUpdateAutomation
 metadata:
   name: resumelo-prod

--- a/apps/production/test-app/helmrelease.yaml
+++ b/apps/production/test-app/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: test-app

--- a/apps/production/test-app/helmrepository-podinfo.yaml
+++ b/apps/production/test-app/helmrepository-podinfo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: podinfo

--- a/apps/production/umami/helmrelease.yaml
+++ b/apps/production/umami/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: umami

--- a/apps/production/umami/helmrepository.yaml
+++ b/apps/production/umami/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: christianhuth

--- a/infrastructure/controllers/cert-manager-porkbun-webhook/helmrelease.yaml
+++ b/infrastructure/controllers/cert-manager-porkbun-webhook/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: porkbun-webhook

--- a/infrastructure/controllers/cert-manager-porkbun-webhook/helmrepository.yaml
+++ b/infrastructure/controllers/cert-manager-porkbun-webhook/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: konnektr

--- a/infrastructure/controllers/cloudnative-pg/helmrelease.yaml
+++ b/infrastructure/controllers/cloudnative-pg/helmrelease.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: cloudnative-pg

--- a/infrastructure/controllers/cloudnative-pg/helmrepository.yaml
+++ b/infrastructure/controllers/cloudnative-pg/helmrepository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cnpg

--- a/infrastructure/controllers/external-dns/helm-release.yaml
+++ b/infrastructure/controllers/external-dns/helm-release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/infrastructure/controllers/external-dns/helmrepository.yaml
+++ b/infrastructure/controllers/external-dns/helmrepository.yaml
@@ -1,6 +1,6 @@
 # On hold due to there is no stable webhook provider for porkbun
 
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: bitnami


### PR DESCRIPTION
## Summary
- run `flux migrate -f . --yes` to update Flux manifests to the GA APIs
- bump every `HelmRelease`, `HelmRepository`, and image automation resource from beta to stable versions

## Testing
- n/a