### PR TITLE
Pin Alloy chart to published release

### DIFF
--- a/infrastructure/controllers/alloy/helmrelease.yaml
+++ b/infrastructure/controllers/alloy/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: alloy
+      version: 1.7.0
       sourceRef:
         kind: HelmRepository
         name: grafana-loki


### PR DESCRIPTION
## Summary
- set the Alloy HelmRelease to version 1.7.0 so Flux uses an available chart artifact

## Testing
- kustomize build infrastructure/controllers
