### PR TITLE
feat: add system-upgrade-controller for automated K3s upgrades

### DIFF
--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - flux-operator
+- system-upgrade-controller
 - metallb
 - nginx-ingress-controller
 - longhorn

--- a/infrastructure/controllers/system-upgrade-controller/controller.yaml
+++ b/infrastructure/controllers/system-upgrade-controller/controller.yaml
@@ -1,0 +1,317 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resourceNames:
+      - system-upgrade-controller
+    resources:
+      - leases
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - upgrade.cattle.io
+    resources:
+      - plans
+      - plans/status
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-drainer
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-upgrade
+  namespace: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-upgrade-controller
+subjects:
+  - kind: ServiceAccount
+    name: system-upgrade
+    namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller
+subjects:
+  - kind: ServiceAccount
+    name: system-upgrade
+    namespace: system-upgrade
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade-drainer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-drainer
+subjects:
+  - kind: ServiceAccount
+    name: system-upgrade
+    namespace: system-upgrade
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-controller-env
+  namespace: system-upgrade
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: "false"
+  SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT: "true"
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: "2"
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: "900"
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: "99"
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: Always
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: rancher/kubectl:v1.30.3
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE_WINDOWS: ""
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: "true"
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: "900"
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: 15m
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: system-upgrade
+spec:
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: system-upgrade-controller
+        upgrade.cattle.io/controller: system-upgrade-controller
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                      - system-upgrade-controller
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: system-upgrade-controller
+          image: rancher/system-upgrade-controller:v0.19.2
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['upgrade.cattle.io/controller']
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SYSTEM_UPGRADE_CONTROLLER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          envFrom:
+            - configMapRef:
+                name: default-controller-env
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsGroup: 65534
+            runAsNonRoot: true
+            runAsUser: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/ssl
+              name: etc-ssl
+              readOnly: true
+            - mountPath: /etc/pki
+              name: etc-pki
+              readOnly: true
+            - mountPath: /etc/ca-certificates
+              name: etc-ca-certificates
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+      serviceAccountName: system-upgrade
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/controlplane
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
+        - effect: NoExecute
+          key: node-role.kubernetes.io/etcd
+          operator: Exists
+      volumes:
+        - hostPath:
+            path: /etc/ssl
+            type: DirectoryOrCreate
+          name: etc-ssl
+        - hostPath:
+            path: /etc/pki
+            type: DirectoryOrCreate
+          name: etc-pki
+        - hostPath:
+            path: /etc/ca-certificates
+            type: DirectoryOrCreate
+          name: etc-ca-certificates
+        - emptyDir: {}
+          name: tmp

--- a/infrastructure/controllers/system-upgrade-controller/kustomization.yaml
+++ b/infrastructure/controllers/system-upgrade-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - https://github.com/rancher/system-upgrade-controller/releases/download/v0.19.2/crd.yaml
+  - controller.yaml
+  - plans.yaml

--- a/infrastructure/controllers/system-upgrade-controller/namespace.yaml
+++ b/infrastructure/controllers/system-upgrade-controller/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: system-upgrade
+  labels:
+    pod-security.kubernetes.io/enforce: privileged

--- a/infrastructure/controllers/system-upgrade-controller/plans.yaml
+++ b/infrastructure/controllers/system-upgrade-controller/plans.yaml
@@ -1,0 +1,58 @@
+---
+# Server (control-plane) upgrade plan - runs first
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: k3s-server
+  namespace: system-upgrade
+  labels:
+    k3s-upgrade: server
+spec:
+  concurrency: 1
+  channel: https://update.k3s.io/v1-release/channels/stable
+  nodeSelector:
+    matchExpressions:
+      - key: k3s-upgrade
+        operator: Exists
+      - key: k3s-upgrade
+        operator: NotIn
+        values: ["disabled", "false"]
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+  serviceAccountName: system-upgrade
+  cordon: true
+  drain:
+    force: true
+    skipWaitForDeleteTimeout: 60
+  upgrade:
+    image: rancher/k3s-upgrade
+---
+# Agent (worker) upgrade plan - waits for server plan to complete
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: k3s-agent
+  namespace: system-upgrade
+  labels:
+    k3s-upgrade: agent
+spec:
+  concurrency: 1
+  channel: https://update.k3s.io/v1-release/channels/stable
+  nodeSelector:
+    matchExpressions:
+      - key: k3s-upgrade
+        operator: Exists
+      - key: k3s-upgrade
+        operator: NotIn
+        values: ["disabled", "false"]
+      - key: node-role.kubernetes.io/control-plane
+        operator: DoesNotExist
+  serviceAccountName: system-upgrade
+  prepare:
+    image: rancher/k3s-upgrade
+    args: ["prepare", "k3s-server"]
+  drain:
+    force: true
+    skipWaitForDeleteTimeout: 60
+  upgrade:
+    image: rancher/k3s-upgrade


### PR DESCRIPTION
## Summary

- Deploys Rancher's [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) v0.19.2 to automate K3s cluster upgrades
- Creates two upgrade Plans tracking the **K3s stable channel** — server nodes upgrade first (concurrency 1), agent nodes follow after verifying the server plan completed
- Uses the official Rancher manifests directly (CRD fetched via Kustomize remote reference) rather than a community Helm chart

## How it works

The controller watches for `Plan` custom resources and schedules upgrade Jobs on matching nodes:

1. **k3s-server plan**: Upgrades control-plane nodes one at a time, cordons and drains before upgrading
2. **k3s-agent plan**: Waits for the server plan to complete (via `prepare` step), then drains and upgrades worker nodes

## Activating upgrades

After merging, label your nodes to opt in:

```bash
kubectl label node master-1 k3s-upgrade=true
kubectl label node worker k3s-upgrade=true
```

To disable upgrades on a node:
```bash
kubectl label node <node> k3s-upgrade=disabled --overwrite
```

## Files added

| File | Purpose |
|------|---------|
| `namespace.yaml` | `system-upgrade` namespace with privileged pod security |
| `controller.yaml` | ServiceAccount, RBAC, ConfigMap, and Deployment for the controller |
| `plans.yaml` | Server and agent upgrade Plans tracking the stable channel |
| `kustomization.yaml` | Ties resources together, fetches CRD from upstream release |

## Current cluster state

| Node | Role | Current K3s Version |
|------|------|-------------------|
| master-1 | control-plane | v1.32.5+k3s1 |
| worker | agent | v1.33.4+k3s1 |

> **Note**: The worker is currently running a newer version than the master. After deployment, the stable channel will bring both nodes to the latest stable release, upgrading the master first.

## Test plan

- [ ] Verify Flux reconciles the new resources successfully: `flux get kustomizations`
- [ ] Confirm the controller pod is running: `kubectl -n system-upgrade get pods`
- [ ] Confirm the CRD is installed: `kubectl get crd plans.upgrade.cattle.io`
- [ ] Label nodes and verify upgrade plans are picked up: `kubectl -n system-upgrade get plans`
- [ ] Monitor upgrade jobs: `kubectl -n system-upgrade get jobs`


Made with [Cursor](https://cursor.com)