### PR TITLE
feat: add system-upgrade-controller for automated K3s upgrades

### DIFF
--- a/infrastructure/controllers/system-upgrade-controller/plans.yaml
+++ b/infrastructure/controllers/system-upgrade-controller/plans.yaml
@@ -1,5 +1,7 @@
 ---
 # Server (control-plane) upgrade plan - runs first
+# IMPORTANT: Bump the channel one minor version at a time.
+# Current path: v1.33 -> v1.34 -> stable (once both nodes are aligned)
 apiVersion: upgrade.cattle.io/v1
 kind: Plan
 metadata:
@@ -9,7 +11,7 @@ metadata:
     k3s-upgrade: server
 spec:
   concurrency: 1
-  channel: https://update.k3s.io/v1-release/channels/stable
+  channel: https://update.k3s.io/v1-release/channels/v1.33
   nodeSelector:
     matchExpressions:
       - key: k3s-upgrade
@@ -37,7 +39,7 @@ metadata:
     k3s-upgrade: agent
 spec:
   concurrency: 1
-  channel: https://update.k3s.io/v1-release/channels/stable
+  channel: https://update.k3s.io/v1-release/channels/v1.33
   nodeSelector:
     matchExpressions:
       - key: k3s-upgrade


### PR DESCRIPTION
## Summary

- Deploys Rancher's [system-upgrade-controller](https://github.com/rancher/system-upgrade-controller) v0.19.2 to automate K3s cluster upgrades
- Creates two upgrade Plans targeting the **K3s v1.33 channel** — server nodes upgrade first (concurrency 1), agent nodes follow after verifying the server plan completed
- Uses the official Rancher manifests directly (CRD fetched via Kustomize remote reference)

## How it works

The controller watches for `Plan` custom resources and schedules upgrade Jobs on matching nodes:

1. **k3s-server plan**: Upgrades control-plane nodes one at a time, cordons and drains before upgrading
2. **k3s-agent plan**: Waits for the server plan to complete (via `prepare` step), then drains and upgrades worker nodes

## Upgrade path

The stable channel currently points to v1.34.6, but master-1 is on v1.32.5. K3s does not support skipping minor versions, so the plans target v1.33 first:

1. **v1.33** (this PR) — master goes v1.32 → v1.33, worker stays on v1.33
2. **v1.34** (follow-up) — bump channel to v1.34 after v1.33 completes
3. **stable** (final) — switch to stable channel once both nodes are aligned

## Activating upgrades

After merging, label nodes to opt in:

```bash
kubectl label node master-1 k3s-upgrade=true
kubectl label node worker k3s-upgrade=true
```

## Test plan

- [ ] Verify Flux reconciles the new resources: `flux get kustomizations`
- [ ] Confirm the controller pod is running: `kubectl -n system-upgrade get pods`
- [ ] Confirm the CRD is installed: `kubectl get crd plans.upgrade.cattle.io`
- [ ] Label nodes and verify upgrade plans are picked up: `kubectl -n system-upgrade get plans`
- [ ] Monitor upgrade jobs: `kubectl -n system-upgrade get jobs`


Made with [Cursor](https://cursor.com)