### PR TITLE
feat(luloclaw): add CNAME DNS record for Tailscale OpenClaw instance

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - tayrona
 - macondo
 - lulo-cms
+- luloclaw

--- a/apps/production/luloclaw/dnsendpoint.yaml
+++ b/apps/production/luloclaw/dnsendpoint.yaml
@@ -1,0 +1,11 @@
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: luloclaw
+  namespace: luloclaw
+spec:
+  endpoints:
+    - dnsName: luloclaw.luloai.com
+      recordType: CNAME
+      targets:
+        - luloclaw.tail6c0c29.ts.net

--- a/apps/production/luloclaw/kustomization.yaml
+++ b/apps/production/luloclaw/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - dnsendpoint.yaml

--- a/apps/production/luloclaw/namespace.yaml
+++ b/apps/production/luloclaw/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: luloclaw

--- a/infrastructure/controllers/external-dns/configmap-helm-values.yaml
+++ b/infrastructure/controllers/external-dns/configmap-helm-values.yaml
@@ -20,6 +20,11 @@ data:
     sources:
       - ingress
       - service
+      - crd
+    
+    extraArgs:
+      crd-source-apiversion: externaldns.k8s.io/v1alpha1
+      crd-source-kind: DNSEndpoint
     
     # Logging and Monitoring
     logLevel: debug

--- a/infrastructure/controllers/external-dns/dnsendpoint-crd.yaml
+++ b/infrastructure/controllers/external-dns/dnsendpoint-crd.yaml
@@ -1,0 +1,97 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            DNSEndpoint is a contract that a user-specified CRD must implement to be used as a source for external-dns.
+            The user-specified CRD should also have the status sub-resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DNSEndpointSpec defines the desired state of DNSEndpoint
+              properties:
+                endpoints:
+                  items:
+                    description: Endpoint is a high-level way of a connection between a service and an IP
+                    properties:
+                      dnsName:
+                        description: The hostname of the DNS record
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels stores labels defined for the Endpoint
+                        type: object
+                      providerSpecific:
+                        description: ProviderSpecific stores provider specific config
+                        items:
+                          description: ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          type: object
+                        type: array
+                      recordTTL:
+                        description: TTL for the record
+                        format: int64
+                        type: integer
+                      recordType:
+                        description: RecordType type of record, e.g. CNAME, A, AAAA, SRV, TXT etc
+                        type: string
+                      setIdentifier:
+                        description: Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+                        type: string
+                      targets:
+                        description: The targets the DNS record points to
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: DNSEndpointStatus defines the observed state of DNSEndpoint
+              properties:
+                observedGeneration:
+                  description: The generation observed by the external-dns controller.
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/infrastructure/controllers/external-dns/kustomization.yaml
+++ b/infrastructure/controllers/external-dns/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
+- dnsendpoint-crd.yaml
 - helmrepository.yaml
 - helm-release.yaml
 - configmap-helm-values.yaml

--- a/infrastructure/controllers/grafana/configmap-helm-values.yaml
+++ b/infrastructure/controllers/grafana/configmap-helm-values.yaml
@@ -8,6 +8,7 @@ data:
   values.yaml: |
     deploymentStrategy:
       type: Recreate
+      rollingUpdate: null
 
     persistence:
       enabled: true


### PR DESCRIPTION
## Summary
- Installs the DNSEndpoint CRD from external-dns to enable declarative DNS record management via Kubernetes resources
- Enables the `crd` source in external-dns and configures `crd-source-apiversion`/`crd-source-kind` so it watches for DNSEndpoint resources
- Adds `luloclaw` app with a DNSEndpoint that creates a CNAME record: `luloclaw.luloai.com` -> `luloclaw.tail6c0c29.ts.net` (Tailscale)
- Fixes Grafana HelmRelease failure by explicitly nulling `rollingUpdate` when using `Recreate` strategy (chart v10.x regression)

## Test plan
- [ ] Verify Flux reconciles the DNSEndpoint CRD successfully
- [ ] Verify external-dns picks up the DNSEndpoint and creates the CNAME in Porkbun
- [ ] Verify `dig luloclaw.luloai.com` resolves to `luloclaw.tail6c0c29.ts.net`
- [ ] Verify Grafana HelmRelease is healthy after the rollingUpdate fix


Made with [Cursor](https://cursor.com)