### PR TITLE
feat(ebay-kleinanzeigen-api): add Flux image auto-update

### DIFF
--- a/apps/production/ebay-kleinanzeigen-api/deployment.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: registry.yesidlopez.de/ebay-kleinanzeigen-api:v1.0.0
+          image: registry.yesidlopez.de/ebay-kleinanzeigen-api:v1.0.0 # {"$imagepolicy": "ebay-kleinanzeigen-api:ebay-kleinanzeigen-api"}
           ports:
             - containerPort: 8000
           resources:

--- a/apps/production/ebay-kleinanzeigen-api/image-automation/imagepolicy.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: ebay-kleinanzeigen-api
+  namespace: ebay-kleinanzeigen-api
+spec:
+  imageRepositoryRef:
+    name: ebay-kleinanzeigen-api
+  policy:
+    semver:
+      range: ">=1.0.0"
+  filterTags:
+    pattern: '^v[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/ebay-kleinanzeigen-api/image-automation/imagerepository.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: ebay-kleinanzeigen-api
+  namespace: ebay-kleinanzeigen-api
+spec:
+  image: registry.yesidlopez.de/ebay-kleinanzeigen-api
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/ebay-kleinanzeigen-api/image-automation/imageupdateautomation.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: ebay-kleinanzeigen-api
+  namespace: ebay-kleinanzeigen-api
+spec:
+  interval: 1m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for ebay-kleinanzeigen-api
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/ebay-kleinanzeigen-api
+    strategy: Setters

--- a/apps/production/ebay-kleinanzeigen-api/image-automation/kustomization.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/ebay-kleinanzeigen-api/kustomization.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - namespace.yaml
   - deployment.yaml
   - service.yaml
+  - sealed-registry-secret.yaml
+  - image-automation/

--- a/apps/production/ebay-kleinanzeigen-api/sealed-registry-secret.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/sealed-registry-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: registry-secret
+  namespace: ebay-kleinanzeigen-api
+spec:
+  encryptedData:
+    .dockerconfigjson: AgAq6/48y9H7rvMDjFLvuepJZi+6u3HItBqbm46fhyL0CP0sLqtPM8MvDrdCWHLdx0/rsxDfB3dzHWk/b38lR2rUEwvO2VMiKcEwaMFcQdRYScJJ8iIXsJdLzOrH7YIkgcSLrGrKL9SDmGEvvcpeX74vQ7HVbT40qUBbl2zWHSbJug0zPhnlDTDVt2yIKRAyHC2AeuP4PPmBh+538UVAAHRbI7wBCaB5YUet9k5julZlLAVGqFY9LjQLd7P/NZDHkw67S9EWqKkvzb12g38eCs4IEjAgw8PvEzImEI8ON9ybw80E8jFnCuFt4aWZyP1Qx/7OrqhXxN7R5yBade+zdCK+VHiG4iZs4WyaO2724WuuakiPzPdYMQXmZC8br15D1n7blgibeLTS+FNzEBF+PSEHNX/1zqeqks9PxBE8FVbFeINnY77B8zI2YlWNfDfp7DDE8tiFSrCLOo8o4y7cfXboM6tXOxYz3qxrrkYrNNFB/jIEFo308/Fvj4vFCoLxFLFtRMPr41I/CW7O7SXuqjW0fIQ1BwUXsHZ2f4rakI5U18r/tzTZmuDThBClwGf6lp0OmCCN3g9sMVi+9KAgRgebFRnieGUoH88xJk+UOGsny3Y9a/kdTS1yl+er/wZXDA0ZBgs9pjvasm2UegFIyDkEdObBW/WHEoH0chiqZY1rcHpUVq4zijWGUaeViW5PFn0gQKyZIIasjT9jcLCpqDR4ZoxyAXYXyxz43wxYwkLiUq0zMbSwiaNBwT13MLdKuH1ob4V4+0TCjI1hZkrSiorbe/cKqykF7kjd+dFkRFjBfg4JYAH219KoQAEWT8Msa27RJzD9sYbsPZcQbY6Un+3h+G+AdtZgOD7H1X1CB4whwoQQrIMBsP/zHvYMr1V2XdhH5GPS0S5ZMV4NLY7Rl8oR7Bn214xFQwFlQPfkAWM=
+  template:
+    metadata:
+      name: registry-secret
+      namespace: ebay-kleinanzeigen-api
+    type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
## Summary
- Adds Flux image automation (ImageRepository, ImagePolicy, ImageUpdateAutomation) for `ebay-kleinanzeigen-api`
- Automatically updates the deployment when a new semver tag (`v*.*.*`, >= 1.0.0) is pushed to `registry.yesidlopez.de/ebay-kleinanzeigen-api`
- Includes sealed `registry-secret` for private registry authentication

## Test plan
- [ ] Verify Flux reconciles the image automation resources
- [ ] Confirm `ImageRepository` scans the registry successfully: `flux get image repository -n ebay-kleinanzeigen-api`
- [ ] Push a `v1.0.1` tag and verify Flux auto-commits the image update


Made with [Cursor](https://cursor.com)