### PR TITLE
feat(resumelo): add Discord notifications for production pod alerts

### DIFF
--- a/apps/production/resumelo/prod/kustomization.yaml
+++ b/apps/production/resumelo/prod/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../base
   - sealed-secrets
   - image-automation
+  - monitoring
 
 patches:
   - path: deployment-patch.yaml

--- a/apps/production/resumelo/prod/monitoring/alertmanager-config.yaml
+++ b/apps/production/resumelo/prod/monitoring/alertmanager-config.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: resumelo-discord
+  namespace: resumelo
+  labels:
+    app: resumelo
+spec:
+  route:
+    receiver: discord
+    groupBy:
+      - alertname
+      - pod
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 1h
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: discord-resumelo-webhook
+            key: apiURL
+          sendResolved: true
+          title: '{{ if eq .Status "firing" }}🔴{{ else }}🟢{{ end }} [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] resumelo-prod'
+          message: '{{ range .Alerts }}**{{ .Annotations.summary }}**{{ "\n" }}{{ .Annotations.description }}{{ "\n" }}Severidad: `{{ .Labels.severity }}`{{ "\n\n" }}{{ end }}'

--- a/apps/production/resumelo/prod/monitoring/discord-webhook-template.yaml
+++ b/apps/production/resumelo/prod/monitoring/discord-webhook-template.yaml
@@ -1,0 +1,21 @@
+# Template para el secret del webhook de Discord.
+# NO commitear este archivo directamente — debe ser sellado primero.
+#
+# Pasos:
+#   1. Reemplaza DISCORD_WEBHOOK_URL con la URL real de tu webhook de Discord
+#      (Ajustes del servidor Discord > Integraciones > Webhooks)
+#   2. Encripta con Sealed Secrets:
+#        make encrypt \
+#          INPUT=apps/production/resumelo/prod/monitoring/discord-webhook-template.yaml \
+#          OUTPUT=apps/production/resumelo/prod/monitoring/sealed-discord-secret.yaml
+#   3. Commitea sealed-discord-secret.yaml
+#   4. Descomenta la línea en monitoring/kustomization.yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: discord-resumelo-webhook
+  namespace: resumelo
+type: Opaque
+stringData:
+  apiURL: "DISCORD_WEBHOOK_URL"

--- a/apps/production/resumelo/prod/monitoring/kustomization.yaml
+++ b/apps/production/resumelo/prod/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheus-rule.yaml
+  - alertmanager-config.yaml
+  # Descomenta una vez creado sealed-discord-secret.yaml:
+  # - sealed-discord-secret.yaml

--- a/apps/production/resumelo/prod/monitoring/kustomization.yaml
+++ b/apps/production/resumelo/prod/monitoring/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 resources:
   - prometheus-rule.yaml
   - alertmanager-config.yaml
-  # Descomenta una vez creado sealed-discord-secret.yaml:
-  # - sealed-discord-secret.yaml
+  - sealed-discord-secret.yaml

--- a/apps/production/resumelo/prod/monitoring/prometheus-rule.yaml
+++ b/apps/production/resumelo/prod/monitoring/prometheus-rule.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: resumelo-prod-alerts
+  namespace: resumelo
+  labels:
+    app: resumelo
+    environment: prod
+spec:
+  groups:
+    - name: resumelo.availability
+      rules:
+        - alert: ResumeloPodNotReady
+          expr: |
+            kube_pod_status_ready{
+              namespace="resumelo",
+              condition="true"
+            } == 0
+          for: 5m
+          labels:
+            severity: critical
+            app: resumelo
+            environment: prod
+          annotations:
+            summary: "Pod {{ $labels.pod }} no está listo"
+            description: "El pod {{ $labels.pod }} en namespace resumelo lleva más de 5 minutos sin estar ready."
+
+        - alert: ResumeloPodCrashLooping
+          expr: |
+            rate(kube_pod_container_status_restarts_total{
+              namespace="resumelo"
+            }[15m]) * 60 * 15 > 1
+          for: 5m
+          labels:
+            severity: critical
+            app: resumelo
+            environment: prod
+          annotations:
+            summary: "Container {{ $labels.container }} en crash loop"
+            description: "El container {{ $labels.container }} del pod {{ $labels.pod }} se ha reiniciado {{ $value | humanize }} veces en 15 minutos."
+
+        - alert: ResumeloDeploymentDown
+          expr: |
+            kube_deployment_status_replicas_available{
+              namespace="resumelo",
+              deployment="resumelo"
+            } == 0
+          for: 2m
+          labels:
+            severity: critical
+            app: resumelo
+            environment: prod
+          annotations:
+            summary: "Deployment resumelo está caído"
+            description: "El deployment resumelo en producción lleva más de 2 minutos sin réplicas disponibles."

--- a/apps/production/resumelo/prod/monitoring/sealed-discord-secret.yaml
+++ b/apps/production/resumelo/prod/monitoring/sealed-discord-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: discord-resumelo-webhook
+  namespace: resumelo
+spec:
+  encryptedData:
+    apiURL: AgCbN/Q3jKCFSAMgCL32Ckxw4/y4+/GGGNynvSc33zpEU4fWsoIMRPtdHeqpWjMBzvLvLC41ON0QfATi5b7xZqkMzeU03Ut6u1TLDu6xWA3B5dw3cven34hTzKZCN1aKZFSNOQ/TWEvMbvty2x9xEMv37oelLkfa8+aUJu75CIkQtsD4At40akxgCgtIjKOSbhXvhuiXqOT/oCa4eK3+cS8f6zpof2ydSF2LgT3OdW8pYal8RbU4IlS3HZ/36PVV7/Zo/siZOxPywTr0Cq0j/wE/72bT5JRtZShuJmk/ULMLg9twhGaIcddq4VJOQgSRQNpWgqwE8HhZ5TE4t4WBG5Ub6PjExN4mIYG8nQzzrXfWEXTLSnKXB2/wLI1zMLqJGNHz/SbQ2lc8FRoCGURVnqU7UaJUQCo2p421MD6nbbK2HP3gtuc73WvSf5/t0dW4LHQCxOwJeQpKOOz8ipf4OXUluM/a4Ck4BWPXrhSGQcFiBacNxQpp/VN1U/cF8PsjZUX8qT2p9iUFULlK04o292IJBa30B5fT/dEUQwQAz71keIvcN5suk/GFvqxHvAXvD2FrnsEWCBBoyxVfxtJuWD3ugnTi7KbWlBjJ5HHO3VLNLwKu6fsx0/qNKv8Czh9dW8iVVr0iXOXfDIuKfqoDQMjqXpnmLo8jZkmL/m1/bo7lSYkAhXWeYvqkq5Xn8PIHE+z75TvpR5EpHh6ZM/3OWW9G2EgfbVUfSpd+VxHM/ah0+K0cIdrA4BmQ6Tm3T3Yhtq2lbn2YYGbqMwxxbWOVq7yi5fV5hNm5prrtVEQxQh/1TuPCJ4iiejjNa7Y5nzyvMujDxD4wK9pTVgxipLOI2k626RW5zrFi4MnX
+  template:
+    metadata:
+      name: discord-resumelo-webhook
+      namespace: resumelo
+    type: Opaque


### PR DESCRIPTION
## Summary
- Adds Prometheus alerting rules for resumelo production: pod not ready, crash looping, and deployment down
- Configures AlertmanagerConfig to route alerts to a Discord channel with formatted messages
- Includes sealed Discord webhook secret and a template for future secret rotation

## Alerts
| Alert | Condition | Fires after |
|-------|-----------|-------------|
| `ResumeloPodNotReady` | Pod not in ready state | 5 min |
| `ResumeloPodCrashLooping` | Container restarting repeatedly | 5 min |
| `ResumeloDeploymentDown` | 0 available replicas | 2 min |

## Test plan
- [ ] Verify Flux reconciles the new monitoring resources in `resumelo` namespace
- [ ] Confirm PrometheusRule is picked up by Prometheus (`kubectl get prometheusrules -n resumelo`)
- [ ] Confirm AlertmanagerConfig is loaded (`kubectl get alertmanagerconfigs -n resumelo`)
- [ ] Confirm sealed secret is unsealed (`kubectl get secret discord-resumelo-webhook -n resumelo`)
- [ ] Optionally scale deployment to 0 to trigger `ResumeloDeploymentDown` and verify Discord notification


Made with [Cursor](https://cursor.com)