### PR TITLE
feat(infra): deploy flux-operator-mcp server in cluster

### DIFF
--- a/infrastructure/controllers/flux-operator-mcp/configmap-helm-values.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/configmap-helm-values.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flux-operator-mcp-helm-chart-value-overrides
+  namespace: flux-system
+data:
+  values.yaml: |-
+    transport: http
+    readonly: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi

--- a/infrastructure/controllers/flux-operator-mcp/helmrelease.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: flux-operator-mcp
+  namespace: flux-system
+spec:
+  interval: 30m
+  releaseName: flux-operator-mcp
+  chartRef:
+    kind: OCIRepository
+    name: flux-operator-mcp
+  install:
+    createNamespace: true
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: flux-operator-mcp-helm-chart-value-overrides
+      valuesKey: values.yaml

--- a/infrastructure/controllers/flux-operator-mcp/kustomization.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml
+  - configmap-helm-values.yaml

--- a/infrastructure/controllers/flux-operator-mcp/ocirepository.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/ocirepository.yaml
@@ -1,0 +1,13 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: flux-operator-mcp
+  namespace: flux-system
+spec:
+  interval: 30m
+  url: oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator-mcp
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    semver: "*"

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
 - grafana
 - alloy
 - prometheus
+- flux-operator-mcp


### PR DESCRIPTION
## Summary

- Deploys the Flux MCP Server (`flux-operator-mcp`) as a pod in the cluster using the OCI Helm chart
- Follows the same OCIRepository + chartRef pattern used by `flux-operator`
- Configured with **HTTP transport** and **read-only mode** so external AI agents (PicoClaw) can inspect Flux resources via MCP without modifying cluster state
- Exposed via a Kubernetes Service on port 9090 in `flux-system` namespace

## Configuration

| Setting | Value | Reason |
|---------|-------|--------|
| `transport` | `http` | Streamable HTTP for PicoClaw MCP client |
| `readonly` | `true` | Prevents cluster modifications via MCP |
| `resources.limits.memory` | `256Mi` | Conservative for homelab |
| `resources.limits.cpu` | `500m` | Conservative for homelab |

## Next steps after merge

- Assign a MetalLB LoadBalancer IP to expose the service on the local network
- Configure PicoClaw to connect to `http://<LB_IP>:9090/mcp`

## Test plan

- [ ] Verify HelmRelease reconciles successfully after merge
- [ ] Verify the pod is running: `kubectl get pods -n flux-system -l app.kubernetes.io/name=flux-operator-mcp`
- [ ] Verify the service is reachable: `kubectl port-forward -n flux-system svc/flux-operator-mcp 9090:9090` then `curl http://localhost:9090/mcp`


Made with [Cursor](https://cursor.com)