### PR TITLE
fix(ci): validate production cluster entrypoint

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -69,6 +69,7 @@ jobs:
           - infrastructure/controllers
           - infrastructure/configs
           - apps/production
+          - clusters/production
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem
The CI workflow validates individual overlays like `infrastructure/controllers`, `infrastructure/configs`, and `apps/production`, but it does not validate `clusters/production`, which is the Flux entrypoint for the production cluster.

## Root cause
A broken reference or invalid composition in `clusters/production` could be merged without being caught by the current `kustomize build` CI job.

## Fix
Add `clusters/production` to the `kustomize-build` matrix so CI validates the same cluster entrypoint that Flux reconciles.
