### PR TITLE
fix(ci): discover Kustomize roots dynamically

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -63,19 +63,22 @@ jobs:
   kustomize-build:
     name: Kustomize build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        overlay:
-          - infrastructure/controllers
-          - infrastructure/configs
-          - apps/production
-          - clusters/production
     steps:
       - uses: actions/checkout@v6
 
       - name: Setup Kustomize
         uses: fluxcd/pkg/actions/kustomize@main
 
-      - name: Build overlay
-        run: kustomize build ${{ matrix.overlay }}
+      - name: Build all Kustomize overlays
+        run: |
+          find infrastructure apps clusters \
+            \( -name kustomization.yaml -o -name kustomization.yml -o -name Kustomization \) \
+            -print0 |
+          xargs -0 -n1 dirname |
+          sort -u |
+          while IFS= read -r overlay; do
+            echo "::group::kustomize build ${overlay}"
+            kustomize build "${overlay}"
+            echo "::endgroup::"
+          done
 


### PR DESCRIPTION
## Problem
The validation workflow had a static Kustomize matrix and tried to run `kustomize build clusters/production`.

`clusters/production` is a Flux cluster entrypoint directory with Flux resources, but it is not itself a Kustomize root because it has no `kustomization.yaml`.

## Root cause
The CI workflow mixed raw manifest validation paths with Kustomize build roots. Raw YAML under `clusters/production` can be validated by kubeconform, but only directories containing a Kustomize file can be built with `kustomize build`.

## Fix
Replace the hardcoded Kustomize build matrix with dynamic discovery of directories containing `kustomization.yaml`, `kustomization.yml`, or `Kustomization` under `infrastructure`, `apps`, and `clusters`.

This prevents future failures when new overlays are added or when cluster entrypoint directories contain raw Flux YAML but are not Kustomize roots.