### PR TITLE
fix: correct Macondo Prometheus scrape port

### DIFF
--- a/apps/production/macondo/service.yaml
+++ b/apps/production/macondo/service.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: macondo
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "80"
+    prometheus.io/port: "8000"
     prometheus.io/path: "/metrics"
 spec:
   selector:


### PR DESCRIPTION
## Problem
Macondo's Service advertises Prometheus scraping on port 80, but the service/container exposes metrics on port 8000.

## Root cause
The `prometheus.io/port` annotation in `apps/production/macondo/service.yaml` was set to `"80"`, causing Alloy/Prometheus to scrape the wrong endpoint.

## Fix
Updated the annotation to `prometheus.io/port: "8000"` so scraping targets the actual Macondo metrics port.

Fixes #18.
