### PR TITLE
feat(umami): weekly Discord analytics report

### DIFF
--- a/apps/production/umami/configmap-weekly-report-script.yaml
+++ b/apps/production/umami/configmap-weekly-report-script.yaml
@@ -17,6 +17,7 @@ data:
     UMAMI_USERNAME = os.environ['UMAMI_USERNAME']
     UMAMI_PASSWORD = os.environ['UMAMI_PASSWORD']
     DISCORD_WEBHOOK_URL = os.environ['DISCORD_WEBHOOK_URL']
+    UMAMI_WEBSITE_NAME = os.environ.get('UMAMI_WEBSITE_NAME', '').strip()
 
 
     def api_request(path, method='GET', data=None, token=None):
@@ -61,7 +62,14 @@ data:
         print("Fetching websites...")
         websites_response = api_request('/api/websites', token=token)
         websites = websites_response if isinstance(websites_response, list) else websites_response.get('data', [])
-        print(f"Found {len(websites)} website(s)")
+
+        if UMAMI_WEBSITE_NAME:
+            websites = [w for w in websites if w.get('name', '').lower() == UMAMI_WEBSITE_NAME.lower()]
+            if not websites:
+                print(f"No website found with name '{UMAMI_WEBSITE_NAME}', aborting.", file=sys.stderr)
+                sys.exit(1)
+
+        print(f"Reporting on {len(websites)} website(s)")
 
         if not websites:
             print("No websites found, skipping report.")

--- a/apps/production/umami/configmap-weekly-report-script.yaml
+++ b/apps/production/umami/configmap-weekly-report-script.yaml
@@ -1,0 +1,125 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: umami-weekly-report-script
+  namespace: umami
+data:
+  report.py: |
+    #!/usr/bin/env python3
+    import os
+    import json
+    import sys
+    import urllib.request
+    import urllib.error
+    from datetime import datetime, timezone, timedelta
+
+    UMAMI_URL = os.environ.get('UMAMI_URL', 'http://umami.umami.svc.cluster.local:3000')
+    UMAMI_USERNAME = os.environ['UMAMI_USERNAME']
+    UMAMI_PASSWORD = os.environ['UMAMI_PASSWORD']
+    DISCORD_WEBHOOK_URL = os.environ['DISCORD_WEBHOOK_URL']
+
+
+    def api_request(path, method='GET', data=None, token=None):
+        url = f"{UMAMI_URL}{path}"
+        headers = {'Content-Type': 'application/json'}
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
+        body = json.dumps(data).encode() if data else None
+        req = urllib.request.Request(url, data=body, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req) as response:
+                return json.loads(response.read())
+        except urllib.error.HTTPError as e:
+            print(f"HTTP error {e.code} for {method} {path}: {e.read().decode()}", file=sys.stderr)
+            raise
+        except urllib.error.URLError as e:
+            print(f"URL error for {method} {path}: {e.reason}", file=sys.stderr)
+            raise
+
+
+    def format_change(change):
+        if not change:
+            return ""
+        arrow = "↑" if change > 0 else "↓"
+        sign = "+" if change > 0 else ""
+        return f" {arrow} {sign}{change}"
+
+
+    def main():
+        end_at = datetime.now(timezone.utc)
+        start_at = end_at - timedelta(days=7)
+        end_ms = int(end_at.timestamp() * 1000)
+        start_ms = int(start_at.timestamp() * 1000)
+
+        print("Authenticating with Umami...")
+        auth = api_request('/api/auth/login', 'POST', {
+            'username': UMAMI_USERNAME,
+            'password': UMAMI_PASSWORD,
+        })
+        token = auth['token']
+
+        print("Fetching websites...")
+        websites_response = api_request('/api/websites', token=token)
+        websites = websites_response if isinstance(websites_response, list) else websites_response.get('data', [])
+        print(f"Found {len(websites)} website(s)")
+
+        if not websites:
+            print("No websites found, skipping report.")
+            return
+
+        fields = []
+        for website in websites:
+            name = website.get('name', website.get('domain', 'Unknown'))
+            print(f"Fetching stats for: {name}")
+            stats = api_request(
+                f"/api/websites/{website['id']}/stats?startAt={start_ms}&endAt={end_ms}",
+                token=token,
+            )
+
+            pageviews = stats.get('pageviews', {}).get('value', 0)
+            pageviews_chg = stats.get('pageviews', {}).get('change', 0)
+            visitors = stats.get('visitors', {}).get('value', 0)
+            visitors_chg = stats.get('visitors', {}).get('change', 0)
+            visits = stats.get('visits', {}).get('value', 0)
+            visits_chg = stats.get('visits', {}).get('change', 0)
+            bounces = stats.get('bounces', {}).get('value', 0)
+            bounce_rate = f"{round(bounces / visits * 100)}%" if visits > 0 else "N/A"
+
+            fields.append({
+                "name": f"📊 {name}",
+                "value": (
+                    f"👥 Visitantes: **{visitors}**{format_change(visitors_chg)}\n"
+                    f"👁️ Vistas: **{pageviews}**{format_change(pageviews_chg)}\n"
+                    f"🔄 Sesiones: **{visits}**{format_change(visits_chg)}\n"
+                    f"↩️ Tasa de rebote: **{bounce_rate}**"
+                ),
+                "inline": True,
+            })
+
+        start_str = start_at.strftime("%d/%m/%Y")
+        end_str = end_at.strftime("%d/%m/%Y")
+
+        payload = {
+            "embeds": [{
+                "title": "📈 Reporte Semanal de Analytics",
+                "description": f"Resumen del **{start_str}** al **{end_str}**",
+                "color": 5793266,
+                "fields": fields,
+                "footer": {"text": "Umami Analytics • Homelab"},
+                "timestamp": end_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            }]
+        }
+
+        print("Sending report to Discord...")
+        req = urllib.request.Request(
+            DISCORD_WEBHOOK_URL,
+            data=json.dumps(payload).encode(),
+            headers={'Content-Type': 'application/json'},
+            method='POST',
+        )
+        with urllib.request.urlopen(req) as response:
+            print(f"Report sent! HTTP {response.status}")
+
+
+    if __name__ == '__main__':
+        main()

--- a/apps/production/umami/cronjob-weekly-report.yaml
+++ b/apps/production/umami/cronjob-weekly-report.yaml
@@ -29,7 +29,7 @@ spec:
                       name: umami-admin-credentials
                       key: adminPassword
                 - name: UMAMI_WEBSITE_NAME
-                  value: "resúmelo"
+                  value: "resumelo"
                 - name: DISCORD_WEBHOOK_URL
                   valueFrom:
                     secretKeyRef:

--- a/apps/production/umami/cronjob-weekly-report.yaml
+++ b/apps/production/umami/cronjob-weekly-report.yaml
@@ -28,6 +28,8 @@ spec:
                     secretKeyRef:
                       name: umami-admin-credentials
                       key: adminPassword
+                - name: UMAMI_WEBSITE_NAME
+                  value: "resúmelo"
                 - name: DISCORD_WEBHOOK_URL
                   valueFrom:
                     secretKeyRef:

--- a/apps/production/umami/cronjob-weekly-report.yaml
+++ b/apps/production/umami/cronjob-weekly-report.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: umami-weekly-report
+  namespace: umami
+spec:
+  schedule: "0 8 * * 1"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: reporter
+              image: python:3.11-alpine
+              command: ["python3", "/scripts/report.py"]
+              volumeMounts:
+                - name: script
+                  mountPath: /scripts
+              env:
+                - name: UMAMI_USERNAME
+                  value: admin
+                - name: UMAMI_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: umami-admin-credentials
+                      key: adminPassword
+                - name: DISCORD_WEBHOOK_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: umami-discord-webhook
+                      key: webhookUrl
+          volumes:
+            - name: script
+              configMap:
+                name: umami-weekly-report-script
+                defaultMode: 0755

--- a/apps/production/umami/discord-webhook-template.yaml
+++ b/apps/production/umami/discord-webhook-template.yaml
@@ -1,0 +1,23 @@
+# Plantilla para crear el Sealed Secret del webhook de Discord para el reporte semanal de Umami.
+#
+# Pasos:
+# 1. En Discord: ve al canal deseado → Editar canal → Integraciones → Webhooks → Nuevo Webhook
+#    Copia la URL del webhook.
+#
+# 2. Crea el archivo secret.yaml con el contenido siguiente (sin confirmar al repositorio):
+#
+#    apiVersion: v1
+#    kind: Secret
+#    metadata:
+#      name: umami-discord-webhook
+#      namespace: umami
+#    type: Opaque
+#    stringData:
+#      webhookUrl: "https://discord.com/api/webhooks/XXXXXXXXXX/XXXXXXXXXX"
+#
+# 3. Encripta el secreto:
+#    make encrypt INPUT=secret.yaml OUTPUT=apps/production/umami/sealed-discord-webhook.yaml
+#
+# 4. Elimina secret.yaml (nunca lo confirmes al repo).
+#
+# 5. Confirma sealed-discord-webhook.yaml al repositorio.

--- a/apps/production/umami/kustomization.yaml
+++ b/apps/production/umami/kustomization.yaml
@@ -8,5 +8,6 @@ resources:
   - postgres-cluster.yaml
   - sealed-umami-admin-credentials.yaml
   - cronjob-sync-admin-password.yaml
+  - sealed-discord-webhook.yaml
   - configmap-weekly-report-script.yaml
   - cronjob-weekly-report.yaml

--- a/apps/production/umami/kustomization.yaml
+++ b/apps/production/umami/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - postgres-cluster.yaml
   - sealed-umami-admin-credentials.yaml
   - cronjob-sync-admin-password.yaml
+  - configmap-weekly-report-script.yaml
+  - cronjob-weekly-report.yaml

--- a/apps/production/umami/sealed-discord-webhook.yaml
+++ b/apps/production/umami/sealed-discord-webhook.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: umami-discord-webhook
+  namespace: umami
+spec:
+  encryptedData:
+    webhookUrl: AgCaesWidMzDLOjeYYHsxYBiktaPC8mlZnzPEqwgSC5PPCd7EbpOtabDXmto/FpQpOrbyPrMNPHZck2VoW0YZMVZWDbCVOfNrDRf5rXKPTvWKX+lgF1WDPDbTSueD1J1gnKWn9lC9TRgKsYf8DehWPT6sqz2IINJ1cd2zFijdQsZcXabCZRCvC5YRlMzTsm4I7wqAJtGXIMS+qjfklMnR/pVzlKWs5rnycvixc1VTRFF3ViUBQhZtCk9/PrAyjRDyIvyyZ6lNoKsvk93DKVGJAGQKiiPuZkderioHovwPj09V5yXoEqiE6l7Ijn6dASIb5H5E8lYkpcoRbhJq4vvSKcAbM+lytYZ1UR7HtW2wo52rNDMymbBejzWsKIaGas6VYv5qEILFPWTDDun4YOZ9318tN16ARckFN34MR6EtqSNtUR1WhlCVRGv8DVzpnjN/H9g2fYf7/Mh8of/bnc2TrFAeBVsOiEPgCvoicKMQMGSEU9RQ06CcfomBDcXAXbjIyWrWYRimo4AwtEGeZNUueJPonRw+/xWXBRLYeT+FsxIA62yXvdhwoZp9KQ/hmdxwa5frf9bk53+ByOotuErylbSv0WLamrQjVwVNSXNgpZkA96DSpKzw/tvT5m+FyxtOGhvweKv8yfwCkaxCCSENN4R+GuP8d5kH1O9WbFyGxuWYgxkLL+fI8gtfg4W8ciIpmOpfjfFlnCcx/bfU7jdXMJxx2bMup2NrkLct5OSo8scsWk4p3//YeEe/h3hq+eLUdJEoT/uMWwYa6BKenilV2QzY3SvnB/pv7U3g9R047iybn5+vfFRmjKuDJuF9LjJ72aVYOCsskxVruWrs7w+3Ck7eFhSx51atIMP
+  template:
+    metadata:
+      name: umami-discord-webhook
+      namespace: umami
+    type: Opaque


### PR DESCRIPTION
## Qué hace este PR

Agrega un CronJob que cada **lunes a las 08:00 UTC** consulta la API de Umami, obtiene las estadísticas de los últimos 7 días y envía un embed formateado a un canal de Discord.

**Métricas incluidas por sitio:**
- 👥 Visitantes únicos (con delta semana a semana)
- 👁️ Vistas de página (con delta semana a semana)
- 🔄 Sesiones (con delta semana a semana)
- ↩️ Tasa de rebote

## Archivos añadidos

| Archivo | Descripción |
|---|---|
| `configmap-weekly-report-script.yaml` | Script Python embebido en ConfigMap |
| `cronjob-weekly-report.yaml` | CronJob semanal (`0 8 * * 1`) |
| `discord-webhook-template.yaml` | Instrucciones para crear el Sealed Secret |

## ⚠️ Pasos pendientes antes de mergear

Este PR **no funcionará** hasta completar los siguientes pasos manualmente, ya que requieren la URL real del webhook de Discord:

### 1. Crear el webhook en Discord

1. Ve al canal de Discord donde quieres recibir el reporte.
2. **Editar canal → Integraciones → Webhooks → Nuevo Webhook.**
3. Dale un nombre (ej. `Umami Analytics`) y copia la URL.

### 2. Crear y encriptar el Sealed Secret

```bash
# Crear el secret (NO lo commitees en claro)
cat <<EOF > /tmp/umami-discord-webhook.yaml
apiVersion: v1
kind: Secret
metadata:
  name: umami-discord-webhook
  namespace: umami
type: Opaque
stringData:
  webhookUrl: "https://discord.com/api/webhooks/TU_ID/TU_TOKEN"
EOF

# Encriptar con Sealed Secrets
make encrypt \
  INPUT=/tmp/umami-discord-webhook.yaml \
  OUTPUT=apps/production/umami/sealed-discord-webhook.yaml

# Eliminar el secret en claro
rm /tmp/umami-discord-webhook.yaml
```

### 3. Agregar el sealed secret al kustomization.yaml

Añadir la siguiente línea en `apps/production/umami/kustomization.yaml`:

```yaml
  - sealed-discord-webhook.yaml
```

### 4. Commitear y pushear

```bash
git add apps/production/umami/sealed-discord-webhook.yaml \
        apps/production/umami/kustomization.yaml
git commit -m "feat(umami): add sealed Discord webhook secret"
git push
```

---

https://claude.ai/code/session_01VyVb3Q9CwUrgyoHNGMwxCn

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyVb3Q9CwUrgyoHNGMwxCn)_