### PR TITLE
fix: increase Flux Helm cache size

### DIFF
--- a/clusters/production/flux-system/flux-instance.yaml
+++ b/clusters/production/flux-system/flux-instance.yaml
@@ -25,4 +25,13 @@ spec:
     ref: refs/heads/main
     path: clusters/production
     pullSecret: flux-system
+  kustomize:
+    patches:
+      - target:
+          kind: Deployment
+          name: source-controller
+        patch: |
+          - op: replace
+            path: /spec/template/spec/containers/0/args/7
+            value: --helm-cache-max-size=100
   wait: true


### PR DESCRIPTION
## Problem
Flux source-controller is failing to cache Helm repository indexes with `failed to cache index: Cache is full`.

## Root cause
The deployed source-controller is generated with `--helm-cache-max-size=10`, which is too low for the number of Helm repositories/charts reconciled in the cluster.

## Fix
Add a FluxInstance kustomize patch for the source-controller Deployment to replace the generated Helm cache limit with `--helm-cache-max-size=100`. This gives Flux more room to cache Helm indexes while keeping the existing TTL and purge interval unchanged.