### PR TITLE
fix(longhorn): configure BackupTarget CRD directly for NFS backup

### DIFF
--- a/infrastructure/configs/longhorn/backup-target.yaml
+++ b/infrastructure/configs/longhorn/backup-target.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: longhorn.io/v1beta2
+kind: BackupTarget
+metadata:
+  name: default
+  namespace: longhorn-system
+spec:
+  backupTargetURL: "nfs://192.168.2.10:/ssd-pool/longhorn-backups"
+  credentialSecret: ""
+  pollInterval: "5m0s"

--- a/infrastructure/configs/longhorn/kustomization.yaml
+++ b/infrastructure/configs/longhorn/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - storage-classes.yaml
 - recurring-jobs.yaml
+- backup-target.yaml

--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -18,5 +18,3 @@ data:
       snapshotMaxCount: 2
       # Enable snapshot purging
       disableSnapshotPurge: false
-      backupTarget: "nfs://192.168.2.10:/ssd-pool/longhorn-backups"
-      backupTargetCredentialSecret: ""


### PR DESCRIPTION
## Summary

- Adds `BackupTarget` CRD manifest pointing to `nfs://192.168.2.10:/ssd-pool/longhorn-backups`
- Removes the now-unused `backupTarget` field from the Helm values ConfigMap

## Why

In Longhorn 1.5+, the backup target is managed through the `BackupTarget` CRD, not via `defaultSettings.backupTarget` in the Helm chart. The original PR #62 set the Helm value but it was silently ignored — the BackupTarget URL remained empty after the upgrade.

The fix adds an explicit `BackupTarget` manifest in `infrastructure/configs/longhorn/` managed by Flux, so the NFS target survives any future reconciliation or Longhorn upgrade.

## Test plan

- [ ] `kubectl -n longhorn-system get backuptargets default -o jsonpath='{.spec.backupTargetURL}'` returns the NFS URL
- [ ] `kubectl -n longhorn-system get backuptargets default -o jsonpath='{.status.available}'` returns `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)