### PR TITLE
fix: add homelab owner attribution

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -674,6 +674,14 @@ footer a {
   text-decoration: none;
 }
 
+.ownerAttribution {
+  margin: 6px 0 0;
+}
+
+.ownerAttribution a {
+  color: var(--text);
+}
+
 .reveal {
   animation: revealUp 720ms ease both;
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -455,7 +455,12 @@ export default function Home() {
       </Section>
 
       <footer>
-        <p>Built with Next.js from a sanitized GitOps homelab repository.</p>
+        <div>
+          <p>Built with Next.js from a sanitized GitOps homelab repository.</p>
+          <p className="ownerAttribution">
+            Homelab Owner: <a href="https://www.yesidlopez.de/">Yesid Lopez</a>
+          </p>
+        </div>
         <a href="https://github.com/yesid-lopez/homelab">github.com/yesid-lopez/homelab</a>
       </footer>
     </main>


### PR DESCRIPTION
## Problem
The homelab website footer did not clearly reference the owner/creator or link to the owner's personal website.

## Root cause
The existing footer only referenced the sanitized GitOps repository and GitHub URL, without a personal attribution.

## Fix
Added a footer attribution reading "Homelab Owner: Yesid Lopez" with a link to https://www.yesidlopez.de/ and small styling so it fits cleanly with the current footer design.

Note: This PR targets feature/homelab-next-webpage because the web/ app is not present on main yet.