### PR TITLE
fix: filter up-to-date Flux notifications

### DIFF
--- a/clusters/production/notifications/alert.yaml
+++ b/clusters/production/notifications/alert.yaml
@@ -29,6 +29,8 @@ spec:
   providerRef:
     name: discord
   eventSeverity: info
+  exclusionList:
+    - "repository up-to-date"
   eventSources:
     - kind: HelmRelease
       name: docker-registry


### PR DESCRIPTION
## Problem
Discord receives noisy Flux info notifications from image automation saying `repository up-to-date` even when no image update happened.

## Root cause
The `flux-system/on-call-info` Alert has `eventSeverity: info` and includes ImageUpdateAutomation resources such as `resumelo/resumelo-prod`, so normal reconciliation events are sent to Discord.

## Fix
Add an `exclusionList` entry to the info Alert for `repository up-to-date`. This keeps image update notifications enabled while suppressing the no-op reconciliation messages.
