### PR TITLE
fix: slow image update automation interval

### DIFF
--- a/apps/production/ebay-kleinanzeigen-api/image-automation/imageupdateautomation.yaml
+++ b/apps/production/ebay-kleinanzeigen-api/image-automation/imageupdateautomation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ebay-kleinanzeigen-api
   namespace: ebay-kleinanzeigen-api
 spec:
-  interval: 1m
+  interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/apps/production/macondo/image-automation/imageupdateautomation.yaml
+++ b/apps/production/macondo/image-automation/imageupdateautomation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: macondo-prod
   namespace: macondo
 spec:
-  interval: 1m
+  interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/apps/production/resumelo/dev/image-automation/imageupdateautomation.yaml
+++ b/apps/production/resumelo/dev/image-automation/imageupdateautomation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resumelo-dev
   namespace: resumelo-dev
 spec:
-  interval: 1m
+  interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/apps/production/resumelo/prod/image-automation/imageupdateautomation.yaml
+++ b/apps/production/resumelo/prod/image-automation/imageupdateautomation.yaml
@@ -4,7 +4,7 @@ metadata:
   name: resumelo-prod
   namespace: resumelo
 spec:
-  interval: 1m
+  interval: 5m
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
## Problem
Flux ImageUpdateAutomation resources were reconciling every 1 minute. This increases GitHub polling and can make transient Git checkout/list-remote failures noisier, like the recent HTTP 500 from GitHub.

## Root cause
All four ImageUpdateAutomation manifests used `spec.interval: 1m`, causing frequent Git operations against the homelab repository.

## Fix
Changed all ImageUpdateAutomation intervals to `5m`:
- ebay-kleinanzeigen-api
- macondo-prod
- resumelo-dev
- resumelo-prod

This reduces GitHub request pressure while still keeping image automation reasonably responsive.