### PR TITLE
fix: raise Longhorn snapshot max count

### DIFF
--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -14,9 +14,9 @@ data:
     defaultSettings:
       # Disable automatic system snapshot creation
       autoCleanupSystemGeneratedSnapshot: false
-      # Allow enough snapshots for daily snapshots and backup-created snapshots.
-      # This must be higher than the recurring snapshot retention, otherwise
-      # Longhorn refuses new snapshots with "snapshot count usage ... snapshotMaxCount".
-      snapshotMaxCount: 32
+      # Keep local snapshots bounded while leaving room for Longhorn to create
+      # the next recurring snapshot before pruning older retained snapshots.
+      # Retention is controlled by the recurring jobs; this is only a safety cap.
+      snapshotMaxCount: 4
       # Enable snapshot purging
       disableSnapshotPurge: false

--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -14,7 +14,9 @@ data:
     defaultSettings:
       # Disable automatic system snapshot creation
       autoCleanupSystemGeneratedSnapshot: false
-      # Set minimum snapshot count
-      snapshotMaxCount: 2
+      # Allow enough snapshots for daily snapshots and backup-created snapshots.
+      # This must be higher than the recurring snapshot retention, otherwise
+      # Longhorn refuses new snapshots with "snapshot count usage ... snapshotMaxCount".
+      snapshotMaxCount: 32
       # Enable snapshot purging
       disableSnapshotPurge: false


### PR DESCRIPTION
## Problem
Daily Longhorn backups did not produce new backups today even though the Kubernetes Job completed.

## Root cause
Longhorn recurring jobs failed internally while creating snapshots. Snapshot CRs show errors like:

`snapshot count usage 2 is equal or larger than snapshotMaxCount 2`

The configured `snapshotMaxCount: 2` is too low for `snapshot-daily` retention plus backup-created snapshots, so Longhorn refuses new snapshots and backups cannot proceed.

Affected PVCs observed include Grafana, Docker registry, Resumelo dev MongoDB, and Umami Postgres volumes.

## Fix
Increase Longhorn `snapshotMaxCount` from `2` to `32` so recurring snapshot and backup jobs have enough headroom for retained snapshots and backup-created snapshots.

Note: existing failed/NotReady Snapshot CRs may need cleanup after this change reconciles.