### PR TITLE
fix: deploy lulo CMS releases via Flux semver

### DIFF
--- a/apps/production/lulo-cms/deployment.yaml
+++ b/apps/production/lulo-cms/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: lulo-cms
-        image: "registry.yesidlopez.de/lulo-cms:v20260510.164843.cd890e9" # {"$imagepolicy": "lulo:lulo-cms"}
+        image: "registry.yesidlopez.de/lulo-cms:cms-v1.0.1" # {"$imagepolicy": "lulo:lulo-cms"}
         ports:
         - containerPort: 3000
         env:

--- a/apps/production/lulo-cms/image-automation/imagepolicy.yaml
+++ b/apps/production/lulo-cms/image-automation/imagepolicy.yaml
@@ -7,5 +7,8 @@ spec:
   imageRepositoryRef:
     name: lulo-cms
   policy:
-    alphabetical:
-      order: asc
+    semver:
+      range: ">=1.0.1"
+  filterTags:
+    pattern: '^cms-v(?P<version>[0-9]+\.[0-9]+\.[0-9]+)$'
+    extract: '$version'


### PR DESCRIPTION
## Problem
Flux Image Automation for lulo-cms was selecting timestamp-based tags alphabetically. We want production deployments to happen from explicit CMS releases instead of every push/build.

## Root cause
The ImagePolicy accepted the old timestamp tag scheme, so the cluster followed build tags rather than release version tags.

## Fix
Switch the lulo-cms ImagePolicy to semver and filter only tags matching `cms-vX.Y.Z`. The deployment image is reset to the release-style baseline `cms-v1.0.1` while preserving the Flux image policy marker, so Flux will update it to the newest valid CMS release tag.