### PR TITLE
feat: mirror MinIO buckets to NFS every 6h

### DIFF
--- a/infrastructure/controllers/minio/cronjob-backup.yaml
+++ b/infrastructure/controllers/minio/cronjob-backup.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-mirror-backup
+  namespace: minio
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mc
+              image: quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z
+              env:
+                - name: MINIO_ROOT_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-credentials
+                      key: rootUser
+                - name: MINIO_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-credentials
+                      key: rootPassword
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  mc alias set local http://minio.minio.svc.cluster.local:9000 \
+                    "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+                  mkdir -p /mnt/mc-mirror
+                  for bucket in payload-media postgres-backups; do
+                    echo "[$(date -Iseconds)] mirroring $bucket"
+                    mc mirror --overwrite --remove \
+                      "local/$bucket" "/mnt/mc-mirror/$bucket"
+                  done
+                  echo "[$(date -Iseconds)] done"
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 500m
+                  memory: 256Mi
+              volumeMounts:
+                - name: nfs-mirror
+                  mountPath: /mnt
+          volumes:
+            - name: nfs-mirror
+              nfs:
+                server: 192.168.2.10
+                path: /ssd-pool/longhorn-backups

--- a/infrastructure/controllers/minio/kustomization.yaml
+++ b/infrastructure/controllers/minio/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - helmrelease.yaml
   - configmap-helm-values.yaml
   - sealed-minio-credentials.yaml
+  - cronjob-backup.yaml


### PR DESCRIPTION
## Summary
Closes the gap where MinIO itself had no off-PVC backup. A `CronJob` in the `minio` namespace runs `mc mirror` every 6h and writes a faithful copy of every bucket to the NAS via NFS.

Without this, the Postgres dumps that #72 ships to MinIO would live only on the MinIO PVC — MinIO would be a single point of failure for its own backups.

### Behavior
- **Schedule**: `0 */6 * * *` (00, 06, 12, 18 UTC), `concurrencyPolicy: Forbid`.
- **Buckets**: `payload-media`, `postgres-backups`.
- **Destination**: `nfs://192.168.2.10:/ssd-pool/longhorn-backups/mc-mirror/<bucket>/...` — reuses the same export Longhorn already writes to.
- **Mode**: `mc mirror --overwrite --remove` → mirror tracks deletions in MinIO; CNPG's 14d retention propagates naturally.
- **Credentials**: existing `minio-credentials` secret (sealed, already in the repo).
- **Image**: `quay.io/minio/mc:RELEASE.2025-04-08T15-39-49Z` (pinned).

### Files
- `infrastructure/controllers/minio/cronjob-backup.yaml` — new CronJob.
- `infrastructure/controllers/minio/kustomization.yaml` — wire it in.

## Verification (run live before this PR)
A one-shot test job from this same manifest:
- Created cleanly, ran in <1s.
- Mirrored **27.15 MiB** (`payload-media`, 11 objects) at 86 MiB/s.
- Mirrored **8.90 MiB** (`postgres-backups`, both CNPG clusters' base + WAL files) at 55 MiB/s.
- NFS layout verified: `/mnt/mc-mirror/{payload-media,postgres-backups/{lulo-cms-postgres,umami-postgres}}/...`.

## Why not Longhorn backup-daily?
The official MinIO Helm chart (`charts.min.io`, v5.4.0) **mentions nothing about backups, replication, or recovery** — it's a pure deployment chart. It exposes `persistence.annotations` but not labels, and Longhorn's `recurring-job-group.longhorn.io/backup` label has to live on the `Volume.longhorn.io` CRD, not the PVC — verified empirically that PVC annotations/labels do not propagate. So Longhorn-based backup for MinIO would require either an off-GitOps `kubectl label volume.longhorn.io`, a Job hack, or migrating to a new StorageClass with `recurringJobSelector`. A `mc mirror` CronJob is the simpler, declarative path and gives **logical**, not block-level, copies.

## Test plan
- [ ] Flux reconciles `infra-controllers`, CronJob `minio/minio-mirror-backup` appears.
- [ ] Next scheduled fire (every 6h) creates a Job; `kubectl logs -n minio job/<name>` shows both buckets mirrored without errors.
- [ ] NFS path on NAS: `/ssd-pool/longhorn-backups/mc-mirror/{payload-media,postgres-backups}` keeps growing/refreshing.
- [ ] If MinIO is wiped, files restore via `mc mirror /mnt/mc-mirror/payload-media local/payload-media`.

## Out of scope (follow-up)
- Off-site copy (Backblaze B2 / R2 / etc.) — currently the mirror sits next to Longhorn's own backups on the same NAS, so a single NAS loss kills both. A second CronJob to B2 (~\$5/mo for 100 GiB) is a reasonable next step.
- Pruning of the mirror directory if buckets ever shrink without `--remove` semantics being enough (not an issue today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)