### PR TITLE
feat: expand Prometheus + PVC usage alerts to Discord

### DIFF
--- a/apps/production/resumelo/prod/monitoring/alertmanager-config.yaml
+++ b/apps/production/resumelo/prod/monitoring/alertmanager-config.yaml
@@ -15,6 +15,9 @@ spec:
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 1h
+    matchers:
+      - name: namespace
+        value: resumelo
   receivers:
     - name: discord
       discordConfigs:

--- a/infrastructure/controllers/prometheus/alerts/alertmanager-discord.yaml
+++ b/infrastructure/controllers/prometheus/alerts/alertmanager-discord.yaml
@@ -1,0 +1,35 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: homelab-discord
+  namespace: prometheus
+  labels:
+    scope: storage
+spec:
+  route:
+    receiver: discord
+    groupBy:
+      - alertname
+      - namespace
+      - persistentvolumeclaim
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 6h
+    matchers:
+      - name: scope
+        value: storage
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: discord-homelab-webhook
+            key: apiURL
+          sendResolved: true
+          title: '{{ if eq .Status "firing" }}🔴{{ else }}🟢{{ end }} [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] homelab storage'
+          message: |
+            {{ range .Alerts -}}
+            **{{ .Annotations.summary }}**
+            {{ .Annotations.description }}
+            Severidad: `{{ .Labels.severity }}`
+
+            {{ end }}

--- a/infrastructure/controllers/prometheus/alerts/kustomization.yaml
+++ b/infrastructure/controllers/prometheus/alerts/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - volume-usage-rules.yaml
+  - alertmanager-discord.yaml
+  - sealed-discord-homelab-webhook.yaml

--- a/infrastructure/controllers/prometheus/alerts/sealed-discord-homelab-webhook.yaml
+++ b/infrastructure/controllers/prometheus/alerts/sealed-discord-homelab-webhook.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: discord-homelab-webhook
+  namespace: prometheus
+spec:
+  encryptedData:
+    apiURL: AgCaNP0a0oIavNXM9K2Icokl8Z+HO3G3zWG6NhY2r7Kb+mI01hSznngimxYA2NTSFyOWIYrK3QkA+v4glcj3wVYWF1DifllZyLJs2SoW/+GMm3yvHAFT8pIWxu2+XrZ/QmFXmzFqiXv4Ms0IFu4A1PBfthg5ltcDsgfvyJqhAsqA8NjP8i/NhSHwh1MMQWAWaYtQWLRdzdi9iRm0hqUBT6H2YhwjAyklLe0lxOfQSG7o7WCe4F+XZg5rS0GYXw0Ykp1RvpbBU7yKK0x+u2Z93XggzTYH3GyAXAEcfTBgWP2gIZS9qPBrnm8vZXIZlomKjciKvbl4aJTjNoQUrrxamizi8Q/U9QLsr68ejWjMOkjc7mhwrZi2bvYwc6fE1ngo/b46AKjtCgrScUcfFCCeJlI6TxxQTSxFE9sArZnGYV1FeDk2BvietDuczwKdQhBoNPbJCgZrRoKVCHeD4xdGyILemOUZAE18Gnfbr9Vk8WjF26leH7wdaZeGzwRQqAvrtgPs+e3VnQAomZ4d4ZUjweuJaQaydhfEqzSSjoxr//EXGVe2T9xqpljf+yQSR1rytoLDHP+Jo/TyLvQQSC6tLfOwDD8RRN931NXb8dU7L6tPk0+0ae4XgLAUmv0nAZ78KB0CPaCKrjQWoaYlDwK6Id8WStoIhBsnbq98JoVIE233OuNXHayLoF6UEW84r6HWx7cKLC41ayHCsKvTKqCm3RA4D12N93LcNGKkbUjB1qUr2BbvRUTiUrhLkRTYKs43J4WcTmP67T3pvka12taNAcq/nFUMDiUMJ+hZ/fJgrdzNQ7w2svzwwBkPzrcwvDNFuwFfKPHgOUjyGnj6k+Cy3WL6eN7yQHzcF7Z2
+  template:
+    metadata:
+      name: discord-homelab-webhook
+      namespace: prometheus

--- a/infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml
+++ b/infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml
@@ -1,0 +1,38 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: volume-usage-alerts
+  namespace: prometheus
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: volume.usage
+      rules:
+        - alert: PersistentVolumeUsageHigh
+          expr: |
+            (
+              kubelet_volume_stats_used_bytes
+              / kubelet_volume_stats_capacity_bytes
+            ) * 100 >= 80
+          for: 10m
+          labels:
+            severity: warning
+            scope: storage
+          annotations:
+            summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} sobre 80%"
+            description: "El PVC {{ $labels.persistentvolumeclaim }} en el namespace {{ $labels.namespace }} está al {{ $value | printf \"%.1f\" }}% de uso."
+
+        - alert: PersistentVolumeUsageCritical
+          expr: |
+            (
+              kubelet_volume_stats_used_bytes
+              / kubelet_volume_stats_capacity_bytes
+            ) * 100 >= 90
+          for: 5m
+          labels:
+            severity: critical
+            scope: storage
+          annotations:
+            summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} sobre 90%"
+            description: "El PVC {{ $labels.persistentvolumeclaim }} en el namespace {{ $labels.namespace }} está al {{ $value | printf \"%.1f\" }}% de uso. Riesgo inminente de llenarse."

--- a/infrastructure/controllers/prometheus/configmap-helm-values.yaml
+++ b/infrastructure/controllers/prometheus/configmap-helm-values.yaml
@@ -15,9 +15,9 @@ data:
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
-                  storage: 20Gi
-        retention: 7d
-        retentionSize: 18GB
+                  storage: 30Gi
+        retention: 14d
+        retentionSize: 24GB
         replicas: 1
         shards: 1
         resources:
@@ -48,6 +48,10 @@ data:
     
     alertmanager:
       alertmanagerSpec:
+        # Allow cross-namespace AlertmanagerConfigs (e.g. prometheus/homelab-discord)
+        # to match alerts from any namespace, not only the one they live in.
+        alertmanagerConfigMatcherStrategy:
+          type: None
         storage:
           volumeClaimTemplate:
             spec:

--- a/infrastructure/controllers/prometheus/kustomization.yaml
+++ b/infrastructure/controllers/prometheus/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - configmap-helm-values.yaml
+  - alerts/


### PR DESCRIPTION
## Summary
Three coordinated changes around Prometheus storage and observability.

### 1. Grow Prometheus PVC and retention
| Setting | Before | After |
|---|---:|---:|
| storage | 20Gi | **30Gi** |
| retention | 7d | **14d** |
| retentionSize | 18GB | **24GB** |

Leaves ~7 GiB of headroom inside the PVC for WAL + pending compaction. **Expansion is automatic**: `prometheus-operator v0.90.1` reconciles `Prometheus.spec.storageSpec.volumeClaimTemplate` directly onto the PVC, and the Longhorn StorageClass has `allowVolumeExpansion: true` — no manual patch needed.

> Note: the "96%" we discussed earlier was Longhorn `actualSize / spec.size`, not filesystem usage. The pod's filesystem is actually at ~24%. The expansion is still worthwhile because (a) retention=14d will grow the working set, (b) Longhorn `actualSize` ≥ spec.size is a smell we don't want sitting near the cap.

### 2. PVC usage alerts (the main ask)
New `PrometheusRule volume-usage-alerts` in `prometheus` namespace:

```promql
(kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) * 100 >= 80   # warning, for 10m
(kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes) * 100 >= 90   # critical, for 5m
```

These measure **filesystem fullness** (what makes the pod fail), not Longhorn block overhead. Carry `scope=storage` so the new AlertmanagerConfig picks them up.

### 3. Route to Discord
- `AlertmanagerConfig homelab-discord` (prometheus ns) matches `scope=storage`, groups by PVC, repeats every 6h.
- New `SealedSecret discord-homelab-webhook` reuses the same Discord webhook URL used by `resumelo`. Easy to switch later if you want a separate channel.

### Side effect: cross-namespace routing
Setting `alertmanagerConfigMatcherStrategy.type: None` is the only way an `AlertmanagerConfig` in `prometheus` can match alerts on PVCs that live in any namespace. The default `OnNamespace` mode auto-injects `namespace=<config-ns>` matcher, which would block our use case.

**Defensive change**: `apps/production/resumelo/prod/monitoring/alertmanager-config.yaml` now declares `matchers: [namespace=resumelo]` explicitly so the resumelo route keeps its existing scope after the strategy switch. Verified no other `AlertmanagerConfig` in the cluster.

## Files
```
M apps/production/resumelo/prod/monitoring/alertmanager-config.yaml
M infrastructure/controllers/prometheus/configmap-helm-values.yaml
M infrastructure/controllers/prometheus/kustomization.yaml
A infrastructure/controllers/prometheus/alerts/alertmanager-discord.yaml
A infrastructure/controllers/prometheus/alerts/kustomization.yaml
A infrastructure/controllers/prometheus/alerts/sealed-discord-homelab-webhook.yaml
A infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml
```

## Test plan
- [ ] `flux get hr -A` shows `kube-prometheus-stack` reconciled cleanly.
- [ ] `kubectl get pvc -n prometheus` shows **30Gi** after the operator reconciles — no manual patch.
- [ ] `kubectl get prometheusrule -n prometheus volume-usage-alerts` exists.
- [ ] `kubectl get alertmanagerconfig -n prometheus homelab-discord` exists.
- [ ] At the Alertmanager UI (`alertmanager.homelab.yesidlopez.de`), the new config appears under "Status".
- [ ] Resumelo route still receives only resumelo alerts (force a synthetic alert or wait for the next firing — the explicit matcher should be enough).
- [ ] Trigger a synthetic test: create a 1Gi PVC, fill it >80%, confirm Discord ping in the homelab channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)