### PR TITLE
fix: unblock Longhorn backups for registry and lulo

### DIFF
--- a/apps/production/lulo-cms/postgres-cluster.yaml
+++ b/apps/production/lulo-cms/postgres-cluster.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   instances: 1
 
+  inheritedMetadata:
+    labels:
+      recurring-job-group.longhorn.io/backup: enabled
+
   bootstrap:
     initdb:
       database: lulo_cms

--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -15,8 +15,8 @@ data:
       # Disable automatic system snapshot creation
       autoCleanupSystemGeneratedSnapshot: false
       # Keep local snapshots bounded while leaving room for Longhorn to create
-      # the next recurring snapshot before pruning older retained snapshots.
+      # new recurring backup snapshots even when retained/manual snapshots exist.
       # Retention is controlled by the recurring jobs; this is only a safety cap.
-      snapshotMaxCount: 4
+      snapshotMaxCount: 8
       # Enable snapshot purging
       disableSnapshotPurge: false


### PR DESCRIPTION
## Problem
The Longhorn daily backup job did not create a new backup for the registry volume, and the lulo CMS Postgres PVC was not included in Longhorn recurring volume backups.

Detected from the Longhorn backup job logs and volume labels:
- registry volume `pvc-822e5b89-b00d-4a8a-ab0c-673611cb9e7b` was selected by `backup-daily`, but snapshot creation timed out.
- lulo CMS Postgres volume `pvc-49dff3a9-58a0-4ef3-bf2a-fc213962ce85` only had the default recurring group and lacked `recurring-job-group.longhorn.io/backup=enabled`.

## Root cause
Registry failed because Longhorn hit the configured snapshot cap:

```
snapshot count usage 4 is equal or larger than snapshotMaxCount 4
```

Longhorn could not create the temporary backup snapshot, so no automatic registry backup was produced. The existing registry backup is the manual one from 2026-05-11.

For lulo CMS, CNPG logical backups to MinIO are now working, but the underlying Longhorn volume was not enrolled in the Longhorn `backup` recurring job group.

## Fix
- Increase Longhorn `snapshotMaxCount` from 4 to 8 so daily snapshots plus retained/manual snapshots leave enough headroom for backup snapshots.
- Add CNPG `inheritedMetadata.labels.recurring-job-group.longhorn.io/backup=enabled` to lulo CMS Postgres so generated PVCs/objects are enrolled in the Longhorn backup group going forward.

Validation:
- `kubectl kustomize apps/production/lulo-cms`
- `kubectl kustomize infrastructure/controllers/longhorn`
- `git diff --check`
