### PR TITLE
fix(longhorn): right-size snapshot cap and retention

### DIFF
--- a/infrastructure/configs/longhorn/recurring-jobs.yaml
+++ b/infrastructure/configs/longhorn/recurring-jobs.yaml
@@ -23,6 +23,6 @@ spec:
   task: backup
   groups:
     - backup
-  retain: 14
+  retain: 7
   concurrency: 2
   labels: {}

--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -12,11 +12,12 @@ data:
     persistence:
       defaultClassReplicaCount: 1
     defaultSettings:
-      # Disable automatic system snapshot creation
-      autoCleanupSystemGeneratedSnapshot: false
-      # Keep local snapshots bounded while leaving room for Longhorn to create
-      # new recurring backup snapshots even when retained/manual snapshots exist.
-      # Retention is controlled by the recurring jobs; this is only a safety cap.
-      snapshotMaxCount: 8
+      # Clean up snapshots Longhorn creates itself (e.g. failed recurring-job
+      # attempts), so stuck ghost CRs don't permanently consume cap slots.
+      autoCleanupSystemGeneratedSnapshot: true
+      # Cap must exceed (backup-daily.retain + snapshot-daily.retain + manual)
+      # plus headroom for the create-before-prune transient peak.
+      # Sized for backup-daily.retain=7 + snap-daily.retain=2 + 1 manual + 2 margin.
+      snapshotMaxCount: 12
       # Enable snapshot purging
       disableSnapshotPurge: false


### PR DESCRIPTION
## Summary
- Lower `backup-daily.retain` from 14 → 7 (S3 backup target keeps longer history)
- Raise `defaultSettings.snapshotMaxCount` from 8 → 12 so it fits steady state (7 backup-d + 2 snap-daily + 1 manual) + create-before-prune peak + margin
- Flip `autoCleanupSystemGeneratedSnapshot` false → true so failed recurring-job snapshots don't accumulate as permanent slot-consumers

## Why
The previous values were mathematically incompatible: steady-state snapshot usage (17 with retain=14) exceeded the cap (8). Once volumes filled, new recurring snapshots couldn't be created, and each failed run left a stuck `ready=false` ghost CR — accelerating the next failure. Today's `backup-daily` (2026-05-13 02:00 UTC) failed on all 4 backup-enabled volumes for this reason.

## Live-cluster fix already applied (not in this diff)
Existing volume CRs were patched to `spec.snapshotMaxCount: 12` and the stuck ghost CRs were force-deleted, so tonight's run will succeed. `defaultSettings` only affects new volumes — this PR keeps the GitOps source aligned with what was patched live, so a future rebuild gets the same configuration.

## Test plan
- [ ] Flux reconciles `infra-configs` and `infra-controllers` cleanly after merge
- [ ] `kubectl -n longhorn-system get recurringjob backup-daily -o jsonpath='{.spec.retain}'` returns `7`
- [ ] `kubectl -n longhorn-system get setting.longhorn.io snapshot-max-count -o jsonpath='{.value}'` returns `12`
- [ ] `kubectl -n longhorn-system get setting.longhorn.io auto-cleanup-system-generated-snapshot -o jsonpath='{.value}'` returns `true`
- [ ] Tomorrow's `backup-daily` run completes without stuck `ready=false` snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)