### PR TITLE
docs: refresh README backup retention and drop resolved DNS debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Proxmox Host (192.168.2.10)
 | Job | Time | Retention | Storage |
 |---|---|---|---|
 | `snapshot-daily` | 1 AM | 2 snapshots | Local (Longhorn) |
-| `backup-daily` | 2 AM | 14 backups | NFS (Proxmox) |
+| `backup-daily` | 2 AM | 7 backups | NFS (Proxmox) |
 
 ### Backed up volumes
 

--- a/docs/debt-tech.md
+++ b/docs/debt-tech.md
@@ -1,21 +1,6 @@
 
-## External DNS
-
-Currently, due to problems in the porkbun webhook, it does not allow me to put more than one domain, which is currently yesidlopez.de, my plans are add resumelo.me and luloai.com.
-
-The reason of the problem is that it is not possible to send two env variables like:
-```yaml
-          - name: DOMAIN_FILTER
-            value: yesidlopez.de
-          - name: DOMAIN_FILTER
-            value: resumelo.me
-```
-It only recognizes the first one, so there are problems setting up the dns in the domain.
-
-## NGNIX Ingress Controller
+## NGINX Ingress Controller
 
 Currently, due to my current router does not support setting up ips but only devices, that's why I have my ingress controller service to be exposed as a `NodePort`.
 
 Once my new Fritzbox Router has arrived, I am planning to change the service as a `LoadBalancer` and map that ip in my router.
-
-


### PR DESCRIPTION
## Summary
- Audited `README.md` and `docs/` against the live cluster config.
- `README.md`: `backup-daily` retention was still `14 backups`, but `infrastructure/configs/longhorn/recurring-jobs.yaml` was lowered to `retain: 7` in #77 — table now matches.
- `docs/debt-tech.md`: removed the External DNS single-domain limitation. `infrastructure/controllers/external-dns/configmap-helm-values.yaml` already configures `yesidlopez.de`, `resumelo.me` and `luloai.com` via repeated `--domain-filter` args on the Porkbun webhook sidecar, so the note no longer reflects reality. Also fixed the `NGNIX` heading typo while there.

Items checked and left as-is:
- NGINX ingress is still exposed as `NodePort` (router constraint), so that debt note stays.
- Hardware section, cluster bootstrap commands, swap/cgroup notes, sealed-secrets workflow and the "Backed up volumes" table all still match the cluster.

## Test plan
- [ ] `git diff main...docs/refresh-readme-and-debt-tech` shows only the README retention line and the debt-tech.md cleanup.
- [ ] Markdown renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)