### PR TITLE
feat(minio): expose payload-media publicly at media.luloai.com

### DIFF
--- a/infrastructure/controllers/minio/configmap-helm-values.yaml
+++ b/infrastructure/controllers/minio/configmap-helm-values.yaml
@@ -33,8 +33,11 @@ data:
     consoleIngress:
       enabled: false
     buckets:
+      # payload-media is fronted by the media.luloai.com ingress and serves
+      # public assets (case-study mockups, etc.) directly to the landing site.
+      # Only this bucket is public — postgres-backups stays private.
       - name: payload-media
-        policy: none
+        policy: download
         purge: false
       - name: postgres-backups
         policy: none

--- a/infrastructure/controllers/minio/ingress.yaml
+++ b/infrastructure/controllers/minio/ingress.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-media-ingress
+  namespace: minio
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+    # MinIO streams object bodies; disable size cap and let large GETs through.
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - media.luloai.com
+      secretName: minio-media-tls
+  rules:
+    - host: media.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000

--- a/infrastructure/controllers/minio/kustomization.yaml
+++ b/infrastructure/controllers/minio/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - configmap-helm-values.yaml
   - sealed-minio-credentials.yaml
   - cronjob-backup.yaml
+  - ingress.yaml


### PR DESCRIPTION
## Summary
- Adds `infrastructure/controllers/minio/ingress.yaml` — public ingress at `media.luloai.com` → `service/minio:9000`. Reuses the established luloai pattern: `luloai-issuer` for TLS, `external-dns.alpha.kubernetes.io/target: homelab.luloai.com` for DNS.
- Flips `buckets[payload-media].policy` from `none` → `download` in the MinIO Helm values. `postgres-backups` stays `none`.
- Registers the new ingress in the minio kustomization.

## Why
The lulo landing site needs to serve case-study mockup images from the CMS-managed `payload-media` bucket. Today, Payload only emits in-cluster URLs (`http://minio.minio.svc.cluster.local:9000/...`) which are unreachable from browsers. Exposing the bucket behind a public TLS endpoint unblocks switching the landing site from hardcoded `public/case_studies/...` paths to CMS-driven media (separate PR in `yesid-lopez/lulo`).

## Scope / safety
- **`policy: download` makes every object in `payload-media` publicly readable by URL.** Acceptable for case-study mockups (the intended use). If the bucket ever needs to host non-public uploads, swap to a custom bucket policy scoped to a `public/*` prefix.
- `postgres-backups` is untouched and remains private.
- Standard ingress controls only (`ssl-redirect`, `proxy-body-size: "0"`, `proxy-buffering: off`).

## Verification before merge
- [ ] `kustomize build infrastructure/controllers/minio` succeeds locally (✅ verified — new `Ingress` rendered alongside existing resources).

## Verification after merge (Flux reconciles)
- [ ] `kubectl get ingress -n minio minio-media-ingress` exists; cert is issued (`kubectl get certificate -n minio`).
- [ ] `dig media.luloai.com` resolves to the cluster ingress IP via external-dns.
- [ ] `curl -I https://media.luloai.com/payload-media/<known-key>` returns 200 anonymously.
- [ ] `curl -I https://media.luloai.com/postgres-backups/` returns 403 (still private).

## Follow-up (separate PR, not blocking)
Once the public endpoint is live, the lulo CMS deployment env (`apps/production/lulo-cms/deployment.yaml`) will get an `S3_PUBLIC_URL=https://media.luloai.com` entry so Payload returns public URLs to API clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)