### PR TITLE
feat(lulo-cms): set S3_PUBLIC_URL=https://media.luloai.com

### DIFF
--- a/apps/production/lulo-cms/deployment.yaml
+++ b/apps/production/lulo-cms/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           value: "us-east-1"
         - name: S3_FORCE_PATH_STYLE
           value: "true"
+        - name: S3_PUBLIC_URL
+          value: "https://media.luloai.com"
         - name: S3_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary
Adds `S3_PUBLIC_URL=https://media.luloai.com` to the lulo-cms Deployment env.

## Why
PR #79 exposed `media.luloai.com` publicly. This env var is the second half of the change: the lulo-cms code (companion PR in `yesid-lopez/lulo`) uses `S3_PUBLIC_URL` as the base for media URLs returned by the API, replacing the in-cluster endpoint that browsers can't reach. Without this var, the new code falls back to `S3_ENDPOINT` and we'd still emit `http://minio.minio.svc.cluster.local:9000/...`.

## Safe to merge in any order
The env var has no effect on the current image (it doesn't read `S3_PUBLIC_URL`). It only kicks in once the companion lulo PR is merged and the image-automation flow rolls out a new lulo-cms image.

## Verification after merge
- [ ] `kubectl get deployment lulo-cms -n lulo -o jsonpath='{.spec.template.spec.containers[0].env}' | grep S3_PUBLIC_URL`
- [ ] After lulo PR + image roll: `curl https://cms.luloai.com/api/media?limit=1 | jq '.docs[0].url'` returns a `https://media.luloai.com/...` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)