### PR TITLE
feat(lulo-cms): run payload migrate via init container

### DIFF
--- a/apps/production/lulo-cms/deployment.yaml
+++ b/apps/production/lulo-cms/deployment.yaml
@@ -16,9 +16,34 @@ spec:
         app: lulo-cms
         name: lulo-cms
     spec:
+      initContainers:
+      - name: migrate
+        image: "registry.yesidlopez.de/lulo-cms:cms-v1.3.2" # {"$imagepolicy": "lulo:lulo-cms"}
+        command: ["node", "./node_modules/.bin/payload"]
+        args: ["migrate"]
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: DATABASE_URI
+          valueFrom:
+            secretKeyRef:
+              name: lulo-cms-postgres-app
+              key: uri
+        - name: PAYLOAD_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: payload-secrets
+              key: PAYLOAD_SECRET
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
       containers:
       - name: lulo-cms
-        image: "registry.yesidlopez.de/lulo-cms:cms-v1.3.1" # {"$imagepolicy": "lulo:lulo-cms"}
+        image: "registry.yesidlopez.de/lulo-cms:cms-v1.3.2" # {"$imagepolicy": "lulo:lulo-cms"}
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
## Summary
- Adds an `initContainers` block to `lulo-cms` Deployment that runs `payload migrate` against the Postgres cluster before the app container starts.
- The init container reuses the CMS image, only needs `DATABASE_URI` + `PAYLOAD_SECRET`, and is safe to re-run on every pod restart (Payload tracks applied migrations in `payload_migrations`).
- Duplicates the `# {"$imagepolicy": "lulo:lulo-cms"}` marker on both image lines so Flux's image automation bumps init + app together — preventing the init container from drifting onto an old tag and running a stale migrate against a newer schema.
- Bumps both image tags to `cms-v1.3.2`, the release that ships the matching Dockerfile change (`node_modules` + `src/migrations` + `src/payload.config.ts` retained in the runner stage so `payload migrate` is runnable from the standalone build).

## Rollout
This PR is step 4 in the planned rollout:
1. `flux suspend image update lulo-cms`
2. Merge Dockerfile PR in `landings/lulo`
3. Tag + publish `cms-v1.3.2` (cms-publish.yml builds + pushes)
4. **Merge this PR** — Flux Kustomization picks it up
5. `flux reconcile kustomization lulo-cms` — pod restarts, init container runs migration `20260513_120000`, app container starts on the new image
6. `flux resume image update lulo-cms`

Do not merge before step 3 — the deployment will ImagePullBackOff on `cms-v1.3.2`.

## Test plan
- [ ] `cms-v1.3.2` exists in `registry.yesidlopez.de/lulo-cms` before merge
- [ ] After reconcile: `kubectl -n lulo get pods -l app=lulo-cms` shows init container completed, app running
- [ ] `kubectl -n lulo logs <pod> -c migrate` shows the new migration applied
- [ ] `\d case_studies` in Postgres shows `platform` column NOT NULL
- [ ] `curl https://<cms-host>/api/case-studies?where[status][equals]=published | jq '.docs[].platform'` returns a value on every doc

## Rollback
Init container failure → pod stays `Init:Error`, prior pod keeps serving. Revert this PR or pin both tags back to `cms-v1.3.1`, then investigate migrate logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)