### PR TITLE
fix(lulo-cms): exec payload bin shim directly, not via node

### DIFF
--- a/apps/production/lulo-cms/deployment.yaml
+++ b/apps/production/lulo-cms/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       initContainers:
       - name: migrate
         image: "registry.yesidlopez.de/lulo-cms:cms-v1.3.2" # {"$imagepolicy": "lulo:lulo-cms"}
-        command: ["node", "./node_modules/.bin/payload"]
+        command: ["./node_modules/.bin/payload"]
         args: ["migrate"]
         env:
         - name: NODE_ENV


### PR DESCRIPTION
## Summary
Hotfix for the init container introduced in #81. The new pod is `Init:CrashLoopBackOff` with `Cannot find module '/app/node_modules/.bin/payload'`.

Cause: pnpm's `node_modules/.bin/payload` is a **shell script** (`#!/bin/sh`), not a JS file. It sets `NODE_PATH` for pnpm's nested layout and then `exec node $basedir/../payload/bin.js "$@"`. Running it as `node ./node_modules/.bin/payload` makes Node parse the shim as JavaScript and fail with `MODULE_NOT_FOUND`.

The shim is already `+x` and has the correct shebang — just drop the `node` prefix and exec it directly. Old pod is still serving traffic, no downtime.

## Test plan
- [ ] After merge + reconcile, `kubectl -n lulo logs <pod> -c migrate` shows the migration applied (or "no migrations to run")
- [ ] App container reaches `Running` and serves on `cms-v1.3.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)