### PR TITLE
fix(multica): route backend paths through ingress

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -54,6 +54,27 @@ data:
       hosts:
         - host: multica.yesidlopez.de
           paths:
+            - path: /api
+              pathType: Prefix
+              service: backend
+            - path: /auth
+              pathType: Prefix
+              service: backend
+            - path: /uploads
+              pathType: Prefix
+              service: backend
+            - path: /ws
+              pathType: Prefix
+              service: backend
+            - path: /health
+              pathType: Prefix
+              service: backend
+            - path: /healthz
+              pathType: Prefix
+              service: backend
+            - path: /readyz
+              pathType: Prefix
+              service: backend
             - path: /
               pathType: Prefix
               service: frontend


### PR DESCRIPTION
## Problem

After #83 went live, `multica setup self-host --server-url https://multica.yesidlopez.de` reports the server as unreachable. Curling `/api/health` or `/health` returns `HTTP/2 404` — the response headers (`x-powered-by: Next.js`, the CSP) confirm Next.js is serving them, not the Go backend.

The chart's `values.yaml` says the frontend image "proxies API calls to http://backend:8080" — that turns out to apply only to Next.js Server Actions used by the web UI, not arbitrary backend routes. The CLI, daemon, and any external client hit the backend prefixes directly and were getting eaten by the Next.js catch-all.

## Fix

Adds explicit ingress paths for every top-level prefix the backend exposes (verified against `server/cmd/server/router.go` in the multica source):

| Path | Service |
|---|---|
| `/api` | backend |
| `/auth` | backend |
| `/uploads` | backend |
| `/ws` | backend |
| `/health`, `/healthz`, `/readyz` | backend |
| `/` (catch-all) | frontend |

NGINX Ingress sorts by path length so `/api/*` matches before `/`, no ordering hacks needed.

## Test plan

- [ ] After merge, Flux reconciles HelmRelease and Ingress picks up the new paths.
- [ ] `curl -sI https://multica.yesidlopez.de/health` returns 200.
- [ ] `multica setup self-host --server-url https://multica.yesidlopez.de --app-url https://multica.yesidlopez.de` succeeds with reachability check.
- [ ] `multica login` completes the email-code flow.
- [ ] Web UI at `https://multica.yesidlopez.de/` still loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)