### PR TITLE
fix: add Sara to Multica allowed emails

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -29,7 +29,7 @@ data:
       frontendOrigin: https://multica.yesidlopez.de
       cookieDomain: ""
       allowSignup: "false"
-      allowedEmails: "yesid.leonardo.lopez@hotmail.com"
+      allowedEmails: "yesid.leonardo.lopez@hotmail.com,saraodrada@gmail.com"
       resendFromEmail: noreply@luloai.com
 
     secret:


### PR DESCRIPTION
## Problem
Sara needs to access Multica but her email is not in the configured allowed email list.

## Root cause
Multica signups are restricted with allowSignup false and only emails listed in allowedEmails are permitted.

## Fix
Added saraodrada@gmail.com to apps/production/multica/configmap-helm-values.yaml under allowedEmails.