### PR TITLE
feat(multica): enroll uploads PVC in Longhorn daily backup

### DIFF
--- a/apps/production/multica/helmrelease.yaml
+++ b/apps/production/multica/helmrelease.yaml
@@ -35,3 +35,17 @@ spec:
       valuesKey: googleClientSecret
       targetPath: config.googleClientSecret
       optional: true
+  postRenderers:
+    # TODO: remove once sshine/multica-helm exposes persistence.labels and we
+    # bump to a chart version that includes it. Then move the label into
+    # configmap-helm-values.yaml under persistence.labels.
+    - kustomize:
+        patches:
+          - target:
+              version: v1
+              kind: PersistentVolumeClaim
+              name: multica-uploads
+            patch: |
+              - op: add
+                path: /metadata/labels/recurring-job-group.longhorn.io~1backup
+                value: enabled


### PR DESCRIPTION
## Summary

- Label the `multica-uploads` PVC with `recurring-job-group.longhorn.io/backup=enabled` via a Flux `postRenderers` kustomize patch.
- Longhorn's daily backup RecurringJob (`infrastructure/configs/longhorn/recurring-jobs.yaml`) is group-scoped to `backup`; the multica app volume was previously not enrolled and only had local snapshots (retain 2).
- Postgres is unaffected — it already has off-cluster CNPG/Barman backups to MinIO.

This is a workaround pending [sshine/multica-helm#2](https://github.com/sshine/multica-helm/pull/2), which adds native `persistence.labels` support. Once that's released, we bump the chart version, drop the postRenderer, and set the label in `configmap-helm-values.yaml` under `persistence.labels`.

## Test plan

- [ ] `flux reconcile helmrelease multica -n multica` after merge
- [ ] `kubectl get pvc multica-uploads -n multica -o jsonpath='{.metadata.labels}'` shows the new label
- [ ] `kubectl get volumes.longhorn.io -n longhorn-system -l recurring-job-group.longhorn.io/backup=enabled` includes the multica-uploads volume
- [ ] After 02:00 UTC: a Longhorn `Backup` CR for multica-uploads appears in `longhorn-system`

🤖 Generated with [Claude Code](https://claude.com/claude-code)