### PR TITLE
feat(multica): bump backend & frontend images to v0.3.0

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -7,6 +7,8 @@ data:
   values.yaml: |
     backend:
       replicaCount: 1
+      image:
+        tag: v0.3.0
       resources:
         requests:
           cpu: 100m
@@ -16,6 +18,8 @@ data:
 
     frontend:
       replicaCount: 1
+      image:
+        tag: v0.3.0
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary
- Override `backend.image.tag` and `frontend.image.tag` to `v0.3.0` in `configmap-helm-values.yaml`.
- Helm chart stays on `0.2.29` because `ghcr.io/sshine/charts/multica:0.3.0` is not published yet (only `0.1.0`, `0.2.0`, `0.2.29` exist in the registry).
- The `v0.3.0` images for `ghcr.io/multica-ai/multica-backend` and `ghcr.io/multica-ai/multica-web` are already published.

## Risk
If `v0.3.0` introduces new env vars or config keys that chart `0.2.29` does not expose, the pods may crashloop. Easy rollback: revert this commit (Flux will reconcile back to `v0.2.29` from the chart's `appVersion`).

## Test plan
- [ ] `flux reconcile helmrelease multica -n multica` succeeds
- [ ] `kubectl -n multica get deploy -o jsonpath='{.items[*].spec.template.spec.containers[*].image}'` shows `:v0.3.0` for backend & web
- [ ] Pods reach Ready and `https://multica.yesidlopez.de` serves frontend
- [ ] Backend health endpoints (`/healthz`, `/readyz`) return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)