### PR TITLE
fix(longhorn): pair backup group label with source label on PVCs

### DIFF
--- a/apps/production/lulo-cms/postgres-cluster.yaml
+++ b/apps/production/lulo-cms/postgres-cluster.yaml
@@ -8,6 +8,9 @@ spec:
 
   inheritedMetadata:
     labels:
+      # Pair required: `source` activates PVC→Volume label sync in Longhorn,
+      # and the group label is what the RecurringJob actually matches on.
+      recurring-job.longhorn.io/source: enabled
       recurring-job-group.longhorn.io/backup: enabled
 
   bootstrap:

--- a/apps/production/multica/helmrelease.yaml
+++ b/apps/production/multica/helmrelease.yaml
@@ -36,8 +36,11 @@ spec:
       targetPath: config.googleClientSecret
       optional: true
   postRenderers:
-    # TODO: remove once sshine/multica-helm exposes persistence.labels and we
-    # bump to a chart version that includes it. Then move the label into
+    # Opt the uploads PVC into Longhorn's `backup` RecurringJob group.
+    # Longhorn syncs recurring-job-group labels from PVC to Volume only when
+    # the PVC also carries `recurring-job.longhorn.io/source=enabled`.
+    # TODO: remove once sshine/multica-helm#2 (persistence.labels) is
+    # released and we bump the chart. Then move both labels into
     # configmap-helm-values.yaml under persistence.labels.
     - kustomize:
         patches:
@@ -46,6 +49,9 @@ spec:
               kind: PersistentVolumeClaim
               name: multica-uploads
             patch: |
+              - op: add
+                path: /metadata/labels/recurring-job.longhorn.io~1source
+                value: enabled
               - op: add
                 path: /metadata/labels/recurring-job-group.longhorn.io~1backup
                 value: enabled

--- a/infrastructure/controllers/longhorn/README.md
+++ b/infrastructure/controllers/longhorn/README.md
@@ -5,7 +5,28 @@ The NFS backup target and recurring jobs are managed via `infrastructure/configs
 - `backup-target.yaml` — BackupTarget CRD pointing to `nfs://192.168.2.10:/ssd-pool/longhorn-backups`
 - `recurring-jobs.yaml` — `snapshot-daily` (1 AM, retain 2) and `backup-daily` (2 AM, retain 14)
 
-Volumes to be backed up must have the label `recurring-job-group.longhorn.io/backup=enabled`.
+Volumes are opted into the daily backup job by labels on the **Longhorn Volume CR**. Longhorn can sync those labels from the PVC, but only when the PVC is marked as a "source" — so you need **both** labels on the PVC:
+
+```yaml
+metadata:
+  labels:
+    recurring-job.longhorn.io/source: enabled              # activates PVC → Volume sync
+    recurring-job-group.longhorn.io/backup: enabled        # joins the `backup` group
+```
+
+The group label without the source label is a no-op — Longhorn ignores it. Verify after Flux reconciles:
+
+```bash
+# Volume CR should carry the group label after the periodic sync
+kubectl get volume <pvc-uid> -n longhorn-system \
+  -o jsonpath='{.metadata.labels.recurring-job-group\.longhorn\.io/backup}'
+# A new Backup CR for the volume appears in longhorn-system after 02:00 UTC
+kubectl get backup -n longhorn-system
+```
+
+For CNPG-managed PVCs, set both under `spec.inheritedMetadata.labels` on the Cluster. For Helm charts, set both wherever the chart exposes PVC labels (or use a Flux `postRenderers` patch as a workaround if it doesn't).
+
+Alternative for "every volume from this StorageClass": Longhorn supports a `recurringJobSelector` parameter on the StorageClass. Not used here — we prefer per-app opt-in so the intent is visible in the app's own manifest.
 
 > **Note:** In Longhorn 1.5+, the backup target is configured via the `BackupTarget` CRD directly, not through `defaultSettings.backupTarget` in the Helm chart values.
 


### PR DESCRIPTION
## Summary

Longhorn only syncs `recurring-job-group.longhorn.io/*` labels from a PVC to its `Volume` CR when the PVC **also** carries `recurring-job.longhorn.io/source=enabled` ([docs](https://longhorn.io/docs/latest/snapshots-and-backups/scheduling-backups-and-snapshots/)). The RecurringJob matches on Volume labels, so without the source label the group label on the PVC is silently ignored.

This was the case for two volumes:

- **multica uploads PVC** — the group label was added via postRenderer in #86 but the backup never actually ran. Verified by `kubectl get backup -n longhorn-system` showing zero backups for `pvc-14ae54b2-…`.
- **lulo-cms postgres PVC** — group label is propagated via CNPG `inheritedMetadata.labels`, same silent gap. Data is still safe thanks to CNPG/Barman → MinIO, but the Longhorn defense-in-depth layer was never active. Zero backups for `pvc-49dff3a9-…`.

This PR adds `recurring-job.longhorn.io/source=enabled` alongside the existing group label in both places, and documents the two-label requirement in the Longhorn controller README.

## Test plan

After merge:

- [ ] `flux reconcile helmrelease multica -n multica` + `kubectl reconcile kustomization apps -n flux-system`
- [ ] `kubectl get pvc multica-uploads -n multica -o jsonpath='{.metadata.labels}'` shows **both** labels
- [ ] `kubectl get pvc lulo-cms-postgres-1 -n lulo -o jsonpath='{.metadata.labels}'` shows **both** labels (CNPG may need a rolling restart of the cluster to apply inheritedMetadata)
- [ ] After the Longhorn sync interval (a few minutes), `kubectl get volume <pvc-uid> -n longhorn-system -o jsonpath='{.metadata.labels.recurring-job-group\.longhorn\.io/backup}'` returns `enabled` for both volumes
- [ ] Remove the imperative label I set on `pvc-14ae54b2-…` earlier and verify Longhorn re-adds it via sync
- [ ] After 02:00 UTC: new `Backup` CRs in `longhorn-system` for both volumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)