### PR TITLE
feat(multica): migrate postgres backup to cnpg barman-cloud plugin

### DIFF
--- a/apps/production/multica/postgres-cluster.yaml
+++ b/apps/production/multica/postgres-cluster.yaml
@@ -26,22 +26,33 @@ spec:
       memory: "1Gi"
       cpu: "500m"
 
-  backup:
-    barmanObjectStore:
-      destinationPath: s3://postgres-backups/multica-postgres
-      endpointURL: http://minio.minio.svc.cluster.local:9000
-      s3Credentials:
-        accessKeyId:
-          name: minio-backup-credentials
-          key: ACCESS_KEY_ID
-        secretAccessKey:
-          name: minio-backup-credentials
-          key: ACCESS_SECRET_KEY
-      wal:
-        compression: gzip
-      data:
-        compression: gzip
-    retentionPolicy: "14d"
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: multica-postgres-store
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: multica-postgres-store
+  namespace: multica
+spec:
+  configuration:
+    destinationPath: s3://postgres-backups/multica-postgres
+    endpointURL: http://minio.minio.svc.cluster.local:9000
+    s3Credentials:
+      accessKeyId:
+        name: minio-backup-credentials
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: minio-backup-credentials
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+    data:
+      compression: gzip
+  retentionPolicy: "14d"
 ---
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
@@ -54,3 +65,6 @@ spec:
   cluster:
     name: multica-postgres
   immediate: true
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io

--- a/infrastructure/controllers/kustomization.yaml
+++ b/infrastructure/controllers/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
 - cert-manager
 - cert-manager-porkbun-webhook
 - cloudnative-pg
+- plugin-barman-cloud
 - minio
 - loki
 - grafana

--- a/infrastructure/controllers/plugin-barman-cloud/configmap-helm-values.yaml
+++ b/infrastructure/controllers/plugin-barman-cloud/configmap-helm-values.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-barman-cloud-helm-chart-value-overrides
+  namespace: cnpg-system
+data:
+  values.yaml: |
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/infrastructure/controllers/plugin-barman-cloud/helmrelease.yaml
+++ b/infrastructure/controllers/plugin-barman-cloud/helmrelease.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plugin-barman-cloud
+  namespace: cnpg-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: plugin-barman-cloud
+      version: ">=0.6.0"
+      sourceRef:
+        kind: HelmRepository
+        name: cnpg
+        namespace: cnpg-system
+      interval: 12h
+  valuesFrom:
+    - kind: ConfigMap
+      name: plugin-barman-cloud-helm-chart-value-overrides
+      valuesKey: values.yaml

--- a/infrastructure/controllers/plugin-barman-cloud/kustomization.yaml
+++ b/infrastructure/controllers/plugin-barman-cloud/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrelease.yaml
+  - configmap-helm-values.yaml


### PR DESCRIPTION
## Summary

Fix the silent `ContinuousArchivingFailing` on `multica/multica-postgres` by moving it off the deprecated native Barman backup path and onto the CNPG **Barman Cloud plugin**.

**Root cause**: the multica cluster runs on `ghcr.io/cloudnative-pg/postgresql:17.6-standard-trixie`, which intentionally ships without the `barman-cloud-*` CLI binaries. `spec.backup.barmanObjectStore` invokes those binaries from inside the postgres pod, so WAL archiving was failing with:

```
exec: \"barman-cloud-check-wal-archive\": executable file not found in \$PATH
```

CNPG has deprecated the native Barman path and will remove it entirely in 1.30. The forward path is the plugin: a separate Deployment (`barman-cloud` in `cnpg-system`) that CNPG injects as a sidecar into postgres pods. The sidecar carries the Barman tools, the postgres image stays slim.

## What this PR does

- **`infrastructure/controllers/plugin-barman-cloud/`** — new Helm release (chart `plugin-barman-cloud` 0.6.0, appVersion v0.12.0) in `cnpg-system`, reusing the existing `cnpg` HelmRepository. Modest resource limits (50m/64Mi → 128Mi).
- **`apps/production/multica/postgres-cluster.yaml`**:
  - Replace `spec.backup.barmanObjectStore` with `spec.plugins[]` referencing a new `ObjectStore` CR (`multica-postgres-store`).
  - New `ObjectStore` CR carries the same MinIO destination, endpoint, sealed credentials, compression, and 14d retention.
  - `ScheduledBackup` switches to `method: plugin` + `pluginConfiguration.name: barman-cloud.cloudnative-pg.io`.
- Same MinIO bucket (`s3://postgres-backups/multica-postgres`), same sealed secret (`minio-backup-credentials`) — no MinIO-side changes.

`lulo-cms` stays on `-system-` image + native barman config for now; can migrate in a follow-up PR.

## Safety

- PVC is **not** recreated. CNPG triggers a rolling pod restart (~30s downtime) when `spec.plugins` is added; the data volume stays.
- Webhook validation passes with Flux's field manager (SSA correctly removes the old `spec.backup` block since `kustomize-controller` owns it). Verified:
  ```
  kubectl apply --server-side --dry-run=server --force-conflicts \\
    --field-manager=kustomize-controller -f postgres-cluster.yaml
  cluster.postgresql.cnpg.io/multica-postgres serverside-applied (server dry run)
  scheduledbackup.postgresql.cnpg.io/multica-postgres-daily serverside-applied (server dry run)
  ```
- Pre-migration safety net: I already took an on-demand Longhorn snapshot + NFS backup of `multica-postgres-1` (`multica-postgres-manual-20260514-1204`, 2.65 GB, Completed). Restorable from `nfs://192.168.2.10:/ssd-pool/longhorn-backups` if anything goes sideways.

## Prerequisites already in cluster

- ✅ CNPG operator 1.29.1 (plugin needs ≥ 1.26)
- ✅ cert-manager 1.x (plugin needs it for its self-signed mTLS issuer)
- ✅ `cnpg-system` namespace
- ✅ `minio-backup-credentials` sealed secret in `multica` ns

## Test plan

After merge:

- [ ] `flux reconcile kustomization infra-controllers -n flux-system` → plugin pod `barman-cloud` Ready in `cnpg-system`
- [ ] `kubectl get crd objectstores.barmancloud.cnpg.io` exists
- [ ] `flux reconcile kustomization apps -n flux-system` → multica Cluster reconciled, ObjectStore created
- [ ] `kubectl get cluster multica-postgres -n multica -o jsonpath='{.status.conditions[?(@.type==\"ContinuousArchiving\")]}'` shows `status=True reason=ContinuousArchivingSuccess`
- [ ] `kubectl get backups.postgresql.cnpg.io -n multica` shows the next daily run completes (or trigger one immediately via `kubectl cnpg backup multica-postgres -n multica --method plugin`)
- [ ] MinIO bucket `postgres-backups/multica-postgres/` shows new WAL files

## Rollback

Revert this PR. Flux will re-add `spec.backup.barmanObjectStore` and remove `spec.plugins` — but the image (`17.6-standard-trixie`) still won't have barman binaries, so we'd be back to `ContinuousArchivingFailing`. A real rollback would also require switching the image to `-system-trixie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)