### PR TITLE
feat(lulo-cms): add seed init container after migrate (LUL-5)

### DIFF
--- a/apps/production/lulo-cms/deployment.yaml
+++ b/apps/production/lulo-cms/deployment.yaml
@@ -41,6 +41,30 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+      - name: seed
+        image: "registry.yesidlopez.de/lulo-cms:cms-v1.4.0" # {"$imagepolicy": "lulo:lulo-cms"}
+        command: ["./node_modules/.bin/payload"]
+        args: ["run", "src/seed/index.ts"]
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: DATABASE_URI
+          valueFrom:
+            secretKeyRef:
+              name: lulo-cms-postgres-app
+              key: uri
+        - name: PAYLOAD_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: payload-secrets
+              key: PAYLOAD_SECRET
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
       containers:
       - name: lulo-cms
         image: "registry.yesidlopez.de/lulo-cms:cms-v1.4.0" # {"$imagepolicy": "lulo:lulo-cms"}


### PR DESCRIPTION
## Summary
- Adds a second init container `seed` that runs `payload run src/seed/index.ts` after `migrate` completes, so the CMS is auto-populated with the `case-studies` seed content on every deployment.
- Reuses the same image and secrets as the migrate container (`DATABASE_URI`, `PAYLOAD_SECRET`, `NODE_ENV=production`).
- The seed script is idempotent by default (skips already-existing records), so re-running on every rollout is safe.

Tracks Multica issue **LUL-5**.

## Dependency
The seed script must be present in the production image. The previous Dockerfile in the lulo repo did **not** copy `src/seed/` into the runner stage. Companion PR in `yesid-lopez/lulo` adds that copy:
- https://github.com/yesid-lopez/lulo/pull/new/agent/devops/b19c0059

**Merge order:** ship the lulo Dockerfile PR first, let Flux image automation roll a fresh `cms-v1.x.y` tag through, then merge this PR so the `seed` init container starts from an image that actually contains `src/seed/index.ts`.

## Test plan
- [x] `kubectl apply --dry-run=client` succeeds against the new manifest
- [ ] Once the new image is published, confirm Pod's `seed` init container logs show "skipped" or "created" lines for each case study
- [ ] Confirm the main `lulo-cms` container starts normally after init containers finish