### PR TITLE
feat(lulo-cms): enable Discord release notifications

### DIFF
--- a/clusters/production/notifications/alert.yaml
+++ b/clusters/production/notifications/alert.yaml
@@ -57,6 +57,12 @@ spec:
       name: macondo-prod
       namespace: macondo
     - kind: ImageUpdateAutomation
+      name: lulo-cms
+      namespace: lulo
+    - kind: ImagePolicy
+      name: lulo-cms
+      namespace: lulo
+    - kind: ImageUpdateAutomation
       name: ebay-kleinanzeigen-api
       namespace: ebay-kleinanzeigen-api
     - kind: GitRepository


### PR DESCRIPTION
## Summary
- Adds `lulo-cms` `ImageUpdateAutomation` and `ImagePolicy` to the existing `on-call-info` Flux Alert (`clusters/production/notifications/alert.yaml`)
- Discord will now get an info-level ping whenever a new `cms-v*` tag is detected and the image-automation commits the bump to git, matching how `resumelo-prod` is wired up today

## Test plan
- [ ] After merge, push a new `cms-v*` image to `registry.yesidlopez.de/lulo-cms` and confirm the homelab Discord channel receives both the `ImagePolicy` selection event and the `ImageUpdateAutomation` commit event

🤖 Generated with [Claude Code](https://claude.com/claude-code)