### PR TITLE
docs: refresh README backup table and CLAUDE.md tech-debt notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,26 +20,28 @@ This is a Kubernetes homelab setup using GitOps principles with Flux CD, running
 - **Package Management**: Helm charts for complex applications
 - **Secret Management**: Sealed Secrets for secure secret storage
 - **Ingress**: NGINX Ingress Controller (currently NodePort, planned LoadBalancer)
-- **Storage**: Longhorn for persistent volumes
+- **Storage**: Longhorn for persistent volumes; MinIO for in-cluster S3 (shared object storage and Postgres backups)
+- **Databases**: CloudNativePG for managed Postgres clusters
 - **Load Balancing**: MetalLB (disabled K3s servicelb)
-- **DNS**: External DNS with Porkbun provider
-- **Certificates**: cert-manager with Let's Encrypt and Porkbun webhook
+- **DNS**: External DNS with the konnektr-io Porkbun webhook (serves `yesidlopez.de`, `resumelo.me`, `luloai.com`)
+- **Certificates**: cert-manager with Let's Encrypt and the Porkbun webhook
 
 ## Ingress Configuration
 
 ### Domain Strategy
-- **Primary domains**: `resumelo.me` and `yesidlopez.de`
-- **Subdomain pattern**: Use `homelab.resumelo.me` or `homelab.yesidlopez.de` depending on the application
-- **Target hosts**: Always use `homelab.yesidlopez.de` for yesidlopez.de domain apps, `homelab.resumelo.me` for resumelo.me domain apps
+- **Primary domains**: `yesidlopez.de`, `resumelo.me`, and `luloai.com`
+- **Subdomain pattern**: Use `homelab.<domain>` (e.g. `homelab.yesidlopez.de`, `homelab.resumelo.me`, `homelab.luloai.com`)
+- **Target hosts**: Pick the `homelab.*` target that matches the app's domain
 - Choose domain based on application context and ownership
 
 ### Certificate Issuers
 - **acme-issuer**: Use for `yesidlopez.de` domains
 - **resumelo-issuer**: Use for `resumelo.me` domains
+- **luloai-issuer**: Use for `luloai.com` domains
 
 ### Required Ingress Annotations
-- **cert-manager.io/cluster-issuer**: Set to appropriate issuer (acme-issuer or resumelo-issuer)
-- **external-dns.alpha.kubernetes.io/target**: Set to `homelab.yesidlopez.de` or `homelab.resumelo.me` based on domain
+- **cert-manager.io/cluster-issuer**: Set to the issuer that matches the domain (`acme-issuer`, `resumelo-issuer`, or `luloai-issuer`)
+- **external-dns.alpha.kubernetes.io/target**: Set to the matching `homelab.<domain>` host
 
 ## Directory Structure
 
@@ -47,7 +49,8 @@ This is a Kubernetes homelab setup using GitOps principles with Flux CD, running
 homelab/
 ├── apps/production/          # Application deployments
 │   ├── resumelo/            # Multi-environment app (dev/prod)
-│   ├── langfuse/            # AI observability platform
+│   ├── multica/             # Multica platform (postgres + uploads)
+│   ├── lulo-cms/            # Lulo CMS (Payload + Postgres)
 │   ├── umami/               # Web analytics
 │   └── ...                  # Other applications
 ├── infrastructure/
@@ -113,10 +116,6 @@ Applications using Helm charts follow this pattern:
 
 ## Current Limitations
 
-### External DNS
-- Porkbun webhook only supports single domain (yesidlopez.de)
-- Multiple domains (resumelo.me, luloai.com) planned but blocked by webhook limitation
-
 ### Ingress Controller
 - Currently using NodePort due to router limitations
 - Planned migration to LoadBalancer when new FritzBox router arrives
@@ -139,8 +138,10 @@ Applications using Helm charts follow this pattern:
 ## Key Applications
 
 - **resumelo**: Multi-environment Node.js application with MongoDB
-- **langfuse**: AI observability platform with PostgreSQL
-- **umami**: Web analytics with PostgreSQL
+- **multica**: Multica agent platform (CNPG Postgres + Longhorn-backed uploads PVC)
+- **lulo-cms**: Payload CMS for `luloai.com` (CNPG Postgres, media in MinIO)
+- **ebay-kleinanzeigen-api**: Reverse-proxy API for Kleinanzeigen listings
+- **umami**: Web analytics with CNPG Postgres
 - **docker-registry**: Private Docker registry with UI
 - **ddns-updater**: Dynamic DNS updates
 - **gotenberg**: PDF generation service

--- a/README.md
+++ b/README.md
@@ -84,12 +84,15 @@ Proxmox Host (192.168.2.10)
 
 | Namespace | PVC | App |
 |---|---|---|
-| `grafana` | `grafana` | Grafana dashboards and users |
-| `umami` | `umami-postgres-1` | Umami analytics PostgreSQL |
-| `registry` | `docker-registry` | Private Docker registry |
-| `resumelo-dev` | `mongodb-pvc` | MongoDB (dev environment) |
+| `multica` | `multica-uploads` | Multica user-uploaded files |
+| `multica` | `multica-postgres-1` (CNPG) | Multica PostgreSQL data dir |
+| `lulo` | `lulo-cms-postgres-1` (CNPG) | Lulo CMS PostgreSQL data dir |
 
-Volumes are assigned to the `backup` recurring job group via the label `recurring-job-group.longhorn.io/backup=enabled`. Monitoring volumes (Prometheus, Alertmanager, Loki) are intentionally excluded.
+Volumes are assigned to the `backup` recurring job group via the label `recurring-job-group.longhorn.io/backup=enabled`. CNPG clusters propagate the label to their PVCs through `spec.inheritedMetadata`, paired with `recurring-job.longhorn.io/source=enabled` so Longhorn syncs the group label from PVC → Volume. Monitoring volumes (Prometheus, Alertmanager, Loki) are intentionally excluded.
+
+### PostgreSQL logical backups (CNPG → MinIO → NFS)
+
+CloudNativePG clusters (`multica-postgres`, `lulo-cms-postgres`, `umami-postgres`) ship base backups and WAL to an in-cluster MinIO bucket (`s3://postgres-backups/…`) via the Barman Cloud plugin, with a `14d` retention policy. MinIO buckets are mirrored to the Proxmox NFS share every 6 hours so there is an off-cluster copy independent of the Longhorn flow above.
 
 ### Restore procedure
 


### PR DESCRIPTION
## Summary

Closes [LUL-8](mention://issue/b92bc825-b3af-49e1-b55f-c9a7de7d4613).

- **README.md** — the *Backed up volumes* table was listing PVCs that no longer carry `recurring-job-group.longhorn.io/backup=enabled` (grafana, umami-postgres-1, docker-registry, mongodb-pvc). Replaced with the PVCs that actually are labeled today: `multica-uploads`, `multica-postgres-1` (CNPG), `lulo-cms-postgres-1` (CNPG). Added a short section describing the CNPG → MinIO → NFS logical-backup flow used for the Postgres clusters (`multica-postgres`, `lulo-cms-postgres`, `umami-postgres`).
- **CLAUDE.md** — dropped the resolved *External DNS single-domain* limitation (the konnektr-io Porkbun webhook serves `yesidlopez.de`, `resumelo.me`, and `luloai.com` via repeated `--domain-filter` args); added `luloai.com` and `luloai-issuer` to the Domain Strategy/Issuers sections; removed `langfuse` references (no longer deployed) and listed the current high-traffic apps (`multica`, `lulo-cms`, `ebay-kleinanzeigen-api`, `umami` on CNPG); added MinIO and CloudNativePG to the Technology Stack.
- **docs/debt-tech.md** — intentionally left untouched. NGINX Ingress Controller is still `NodePort` (see `infrastructure/controllers/nginx-ingress-controller/configmap-helm-values.yaml`), so the LoadBalancer migration note remains accurate.

## Test plan

- [ ] Read the rendered README on GitHub and confirm the backup table matches the PVCs actually labeled today (`grep -rn "recurring-job-group.longhorn.io/backup" --include="*.yaml"`).
- [ ] Confirm the CNPG → MinIO retention (`14d`) matches `apps/production/{multica,lulo-cms,umami}/postgres-cluster.yaml`.
- [ ] Confirm CLAUDE.md's *Current Limitations* still has the NGINX Ingress entry only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

edit