### PR TITLE
fix: avoid duplicate Flux notification reconciliation

### DIFF
--- a/clusters/production/kustomization.yaml
+++ b/clusters/production/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - flux-system
+  - apps.yaml
+  - infrastructure.yaml


### PR DESCRIPTION
## Problem
Flux was emitting repeated `configured` progress events for notification resources, especially `SealedSecret/flux-system/discord-webhook-url configured...`. This matched the Flux troubleshooting guidance around repeated configured-event spam.

## Root cause
The root `FluxInstance` syncs `clusters/production`. Because that directory had no root `kustomization.yaml`, Kustomize recursively included `clusters/production/notifications` directly. At the same time, `clusters/production/infrastructure.yaml` defines a separate Flux `Kustomization` named `notifications` pointing to the same `./clusters/production/notifications` path.

As a result, these resources appeared in both inventories:
- `kustomization/flux-system`
- `kustomization/notifications`

The duplicated ownership caused repeated apply/progress events for the same notification resources.

## Fix
Added a root `clusters/production/kustomization.yaml` that explicitly includes only:
- `flux-system`
- `apps.yaml`
- `infrastructure.yaml`

This keeps notification resources managed only by the dedicated `notifications` Kustomization while still allowing the root Flux sync to create that Kustomization.

No direct cluster mutation was performed.