### PR TITLE
chore(multica): bump image tags to v0.3.1

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -8,7 +8,7 @@ data:
     backend:
       replicaCount: 1
       image:
-        tag: v0.3.0
+        tag: v0.3.1
       resources:
         requests:
           cpu: 100m
@@ -27,7 +27,7 @@ data:
     frontend:
       replicaCount: 1
       image:
-        tag: v0.3.0
+        tag: v0.3.1
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary
- Bump `backend.image.tag` and `frontend.image.tag` from `v0.3.0` to `v0.3.1` in `apps/production/multica/configmap-helm-values.yaml`.

## Why
Pick up the [v0.3.1 release](https://github.com/multica-ai/multica/releases/tag/v0.3.1). Notable items for this self-hosted deploy:

- `feat(email)`: SMTP relay as an alternative to Resend for self-hosted deployments.
- `fix(daemon)`: resolve agent CLIs via login shell when daemon PATH misses them.
- `fix(daemon)`: close `handleRuntimeGone` success/straggler race; disable Claude `AskUserQuestion` in non-interactive mode; report task usage before cancel check.
- `fix(issues)`: file-card render for self-host with local storage.
- `fix(projects)` / `fix(repos)`: accept SSH and scp-shorthand repo URLs.
- `fix(runtimes)`: correct pricing for Claude IDs reported as dotted / provider-prefixed.
- `fix(realtime)`: invalidate workspace queries on WSClient instance change; include `actor_type` in WS broadcasts.
- `fix(squad)`: wake leader when dual-role agent posts as worker.
- Squad archive dialog + role editor + transactional `DeleteSquad`.

Chart version (`0.2.29`) is unchanged.

## Test plan
- [ ] Flux reconciles the HelmRelease and rolls out new backend + frontend pods.
- [ ] `kubectl -n multica get pods` shows `multica-backend` and `multica-frontend` on `v0.3.1` images.
- [ ] `https://multica.yesidlopez.de` loads and login works.
- [ ] Smoke-check a runtime / agent run end-to-end (CLI resolution + WS realtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)