### PR TITLE
fix(multica): set fsGroup so uploads PVC is writable

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -15,6 +15,12 @@ data:
           memory: 128Mi
         limits:
           memory: 512Mi
+      # Required so the uploads PVC is chgrp'd to gid 1000 on mount —
+      # otherwise the non-root backend (runAsUser/Group 1000) gets EACCES
+      # creating subdirectories under /app/data/uploads.
+      podSecurityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
       extraEnv:
         - name: GITHUB_APP_SLUG
           value: "multica-luloai"


### PR DESCRIPTION
## Problem

Uploading any file via the web UI fails with `500 Internal Server Error` / `{"error":"upload failed"}`. Backend logs show:

```
ERR file upload failed error="local storage MkdirAll: mkdir data/uploads/workspaces: permission denied"
```

The chart's container `securityContext` runs the backend as `uid=1000, gid=1000`, but the Longhorn PVC mounted at `/app/data/uploads` is owned by `root:root` (`drwxr-xr-x`). Without a pod-level `fsGroup`, kubelet doesn't reconcile the volume's group ownership to the runtime user, so subdir creation hits `EACCES`.

## Fix

Adds `backend.podSecurityContext.fsGroup: 1000` so kubelet chgrp's the volume to gid 1000 on mount.

`fsGroupChangePolicy: OnRootMismatch` keeps it cheap — kubelet only walks the tree when the top-level ownership doesn't already match, instead of every pod start. Matters once the uploads volume has many objects.

## Test plan

- [ ] Flux reconciles → backend pod rolls.
- [ ] `kubectl exec -n multica deploy/multica-backend -- ls -ld /app/data/uploads` shows group `1000`.
- [ ] Upload an image from the Multica web UI → returns 200 (or 201).
- [ ] Backend logs no longer contain `permission denied` for upload paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)