### PR TITLE
feat: add public homelab status API

### DIFF
--- a/apps/production/kustomization.yaml
+++ b/apps/production/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
 - lulo-cms
 - ebay-kleinanzeigen-api
 - multica
+- public-status-api

--- a/apps/production/public-status-api/configmap.yaml
+++ b/apps/production/public-status-api/configmap.yaml
@@ -1,0 +1,177 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: public-status-api-app
+  namespace: public-status-api
+data:
+  app.py: |
+    import json
+    import os
+    import ssl
+    import time
+    import urllib.error
+    import urllib.request
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    PORT = int(os.environ.get("PORT", "8080"))
+    CACHE_TTL_SECONDS = int(os.environ.get("CACHE_TTL_SECONDS", "30"))
+    CORS_ALLOW_ORIGIN = os.environ.get("CORS_ALLOW_ORIGIN", "https://www.yesidlopez.de")
+    API_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
+    API_PORT = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+    API_BASE = f"https://{API_HOST}:{API_PORT}"
+    TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    CA_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+    cache = {"expires_at": 0, "payload": None}
+
+    def read_token():
+        with open(TOKEN_PATH, "r", encoding="utf-8") as token_file:
+            return token_file.read().strip()
+
+    def kube_get(path):
+        context = ssl.create_default_context(cafile=CA_PATH)
+        request = urllib.request.Request(
+            f"{API_BASE}{path}",
+            headers={"Authorization": f"Bearer {read_token()}", "Accept": "application/json"},
+        )
+        with urllib.request.urlopen(request, context=context, timeout=5) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def condition_is_true(resource, condition_type):
+        for condition in resource.get("status", {}).get("conditions", []):
+            if condition.get("type") == condition_type:
+                return condition.get("status") == "True"
+        return False
+
+    def count_unavailable_workloads(resources, kind):
+        unavailable = 0
+        for item in resources.get("items", []):
+            status = item.get("status", {})
+            desired = status.get("replicas") or item.get("spec", {}).get("replicas") or 0
+            ready = status.get("readyReplicas") or status.get("numberReady") or 0
+            if kind == "daemonset":
+                desired = status.get("desiredNumberScheduled") or 0
+            if desired > ready:
+                unavailable += 1
+        return unavailable
+
+    def flux_ready_summary(resources):
+        total = 0
+        not_ready = 0
+        for item in resources.get("items", []):
+            total += 1
+            if not condition_is_true(item, "Ready"):
+                not_ready += 1
+        return total, not_ready
+
+    def build_payload():
+        nodes = kube_get("/api/v1/nodes")
+        pods = kube_get("/api/v1/pods")
+        deployments = kube_get("/apis/apps/v1/deployments")
+        statefulsets = kube_get("/apis/apps/v1/statefulsets")
+        daemonsets = kube_get("/apis/apps/v1/daemonsets")
+        kustomizations = kube_get("/apis/kustomize.toolkit.fluxcd.io/v1/kustomizations")
+        helmreleases = kube_get("/apis/helm.toolkit.fluxcd.io/v2/helmreleases")
+
+        node_count = len(nodes.get("items", []))
+        ready_nodes = sum(1 for node in nodes.get("items", []) if condition_is_true(node, "Ready"))
+        pod_items = pods.get("items", [])
+        running_pods = sum(1 for pod in pod_items if pod.get("status", {}).get("phase") == "Running")
+        problematic_pods = sum(
+            1
+            for pod in pod_items
+            if pod.get("status", {}).get("phase") in ["Failed", "Unknown"]
+        )
+
+        workload_total = (
+            len(deployments.get("items", []))
+            + len(statefulsets.get("items", []))
+            + len(daemonsets.get("items", []))
+        )
+        unavailable_workloads = (
+            count_unavailable_workloads(deployments, "deployment")
+            + count_unavailable_workloads(statefulsets, "statefulset")
+            + count_unavailable_workloads(daemonsets, "daemonset")
+        )
+
+        kustomization_total, kustomization_not_ready = flux_ready_summary(kustomizations)
+        helmrelease_total, helmrelease_not_ready = flux_ready_summary(helmreleases)
+        flux_not_ready = kustomization_not_ready + helmrelease_not_ready
+        alert_count = problematic_pods + unavailable_workloads + flux_not_ready + max(node_count - ready_nodes, 0)
+
+        status = "operational"
+        if ready_nodes < node_count or flux_not_ready > 0 or unavailable_workloads > 0:
+            status = "degraded"
+        if ready_nodes == 0 or problematic_pods > 0:
+            status = "incident"
+
+        return {
+            "status": status,
+            "nodes": ready_nodes,
+            "nodeCount": node_count,
+            "workloads": workload_total,
+            "runningPods": running_pods,
+            "gitops": "healthy" if flux_not_ready == 0 else "degraded",
+            "alerts": alert_count,
+            "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        }
+
+    def get_payload():
+        now = time.time()
+        if cache["payload"] is not None and cache["expires_at"] > now:
+            return cache["payload"]
+        try:
+            payload = build_payload()
+            cache["payload"] = payload
+            cache["expires_at"] = now + CACHE_TTL_SECONDS
+            return payload
+        except Exception as error:
+            fallback = {
+                "status": "unknown",
+                "nodes": None,
+                "nodeCount": None,
+                "workloads": None,
+                "runningPods": None,
+                "gitops": "unknown",
+                "alerts": None,
+                "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "message": "Status is temporarily unavailable.",
+            }
+            if cache["payload"] is not None:
+                stale = dict(cache["payload"])
+                stale["stale"] = True
+                stale["message"] = "Serving cached status while live status is temporarily unavailable."
+                return stale
+            return fallback
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args):
+            return
+
+        def send_json(self, status_code, payload):
+            body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "public, max-age=30")
+            self.send_header("Access-Control-Allow-Origin", CORS_ALLOW_ORIGIN)
+            self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type")
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_OPTIONS(self):
+            self.send_json(204, {})
+
+        def do_GET(self):
+            if self.path in ["/", "/status"]:
+                self.send_json(200, get_payload())
+                return
+            if self.path == "/healthz":
+                self.send_json(200, {"ok": True})
+                return
+            self.send_json(404, {"error": "not found"})
+
+    if __name__ == "__main__":
+        server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+        server.serve_forever()

--- a/apps/production/public-status-api/configmap.yaml
+++ b/apps/production/public-status-api/configmap.yaml
@@ -66,7 +66,6 @@ data:
 
     def build_payload():
         nodes = kube_get("/api/v1/nodes")
-        pods = kube_get("/api/v1/pods")
         deployments = kube_get("/apis/apps/v1/deployments")
         statefulsets = kube_get("/apis/apps/v1/statefulsets")
         daemonsets = kube_get("/apis/apps/v1/daemonsets")
@@ -75,13 +74,6 @@ data:
 
         node_count = len(nodes.get("items", []))
         ready_nodes = sum(1 for node in nodes.get("items", []) if condition_is_true(node, "Ready"))
-        pod_items = pods.get("items", [])
-        running_pods = sum(1 for pod in pod_items if pod.get("status", {}).get("phase") == "Running")
-        problematic_pods = sum(
-            1
-            for pod in pod_items
-            if pod.get("status", {}).get("phase") in ["Failed", "Unknown"]
-        )
 
         workload_total = (
             len(deployments.get("items", []))
@@ -97,12 +89,12 @@ data:
         kustomization_total, kustomization_not_ready = flux_ready_summary(kustomizations)
         helmrelease_total, helmrelease_not_ready = flux_ready_summary(helmreleases)
         flux_not_ready = kustomization_not_ready + helmrelease_not_ready
-        alert_count = problematic_pods + unavailable_workloads + flux_not_ready + max(node_count - ready_nodes, 0)
+        alert_count = unavailable_workloads + flux_not_ready + max(node_count - ready_nodes, 0)
 
         status = "operational"
         if ready_nodes < node_count or flux_not_ready > 0 or unavailable_workloads > 0:
             status = "degraded"
-        if ready_nodes == 0 or problematic_pods > 0:
+        if ready_nodes == 0:
             status = "incident"
 
         return {
@@ -110,7 +102,6 @@ data:
             "nodes": ready_nodes,
             "nodeCount": node_count,
             "workloads": workload_total,
-            "runningPods": running_pods,
             "gitops": "healthy" if flux_not_ready == 0 else "degraded",
             "alerts": alert_count,
             "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -131,7 +122,6 @@ data:
                 "nodes": None,
                 "nodeCount": None,
                 "workloads": None,
-                "runningPods": None,
                 "gitops": "unknown",
                 "alerts": None,
                 "updatedAt": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),

--- a/apps/production/public-status-api/deployment.yaml
+++ b/apps/production/public-status-api/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: public-status-api
-          image: python:3.12-alpine
+          image: python:3.12-alpine@sha256:236173eb74001afe2f60862de935b74fcbd00adfca247b2c27051a70a6a39a2d
           imagePullPolicy: IfNotPresent
           command: ["python", "/app/app.py"]
           ports:

--- a/apps/production/public-status-api/deployment.yaml
+++ b/apps/production/public-status-api/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: public-status-api
+  namespace: public-status-api
+  labels:
+    app: public-status-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: public-status-api
+  template:
+    metadata:
+      labels:
+        app: public-status-api
+    spec:
+      serviceAccountName: public-status-api
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: public-status-api
+          image: python:3.12-alpine
+          imagePullPolicy: IfNotPresent
+          command: ["python", "/app/app.py"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PORT
+              value: "8080"
+            - name: CACHE_TTL_SECONDS
+              value: "30"
+            - name: CORS_ALLOW_ORIGIN
+              value: "https://www.yesidlopez.de"
+          volumeMounts:
+            - name: app
+              mountPath: /app
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: app
+          configMap:
+            name: public-status-api-app

--- a/apps/production/public-status-api/ingress.yaml
+++ b/apps/production/public-status-api/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: public-status-api
+  namespace: public-status-api
+  annotations:
+    cert-manager.io/cluster-issuer: acme-issuer
+    external-dns.alpha.kubernetes.io/hostname: status.yesidlopez.de
+    external-dns.alpha.kubernetes.io/target: homelab.yesidlopez.de
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/limit-rps: "2"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "5"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - status.yesidlopez.de
+      secretName: public-status-api-tls
+  rules:
+    - host: status.yesidlopez.de
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: public-status-api
+                port:
+                  number: 80

--- a/apps/production/public-status-api/kustomization.yaml
+++ b/apps/production/public-status-api/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - networkpolicy.yaml

--- a/apps/production/public-status-api/kustomization.yaml
+++ b/apps/production/public-status-api/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - serviceaccount.yaml
+  - rbac.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/production/public-status-api/namespace.yaml
+++ b/apps/production/public-status-api/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: public-status-api

--- a/apps/production/public-status-api/networkpolicy.yaml
+++ b/apps/production/public-status-api/networkpolicy.yaml
@@ -1,0 +1,38 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: public-status-api
+  namespace: public-status-api
+spec:
+  podSelector:
+    matchLabels:
+      app: public-status-api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: nginx-ingress-controller
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/apps/production/public-status-api/rbac.yaml
+++ b/apps/production/public-status-api/rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: public-status-api-readonly
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["list"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["list"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: public-status-api-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: public-status-api-readonly
+subjects:
+  - kind: ServiceAccount
+    name: public-status-api
+    namespace: public-status-api

--- a/apps/production/public-status-api/rbac.yaml
+++ b/apps/production/public-status-api/rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: public-status-api-readonly
 rules:
   - apiGroups: [""]
-    resources: ["nodes", "pods"]
+    resources: ["nodes"]
     verbs: ["list"]
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets", "daemonsets"]

--- a/apps/production/public-status-api/service.yaml
+++ b/apps/production/public-status-api/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: public-status-api
+  namespace: public-status-api
+spec:
+  selector:
+    app: public-status-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/apps/production/public-status-api/serviceaccount.yaml
+++ b/apps/production/public-status-api/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: public-status-api
+  namespace: public-status-api


### PR DESCRIPTION
## Problem
The homepage status card needs a public, sanitized endpoint for live homelab health data instead of relying on static fallback values.

## Root cause
No public status API existed in the GitOps repo. The frontend can only show live metrics once the cluster exposes a small read-only endpoint.

## Fix
- Add a new `public-status-api` production app managed by Flux/Kustomize.
- Expose `https://status.yesidlopez.de` through nginx ingress with TLS via `acme-issuer` and external-dns.
- Run a lightweight Python HTTP server from a ConfigMap, avoiding a new custom image for the initial version.
- Grant read-only RBAC for aggregate Kubernetes and Flux status only: nodes, pods, apps workloads, Flux Kustomizations, and HelmReleases.
- Return sanitized metrics only: status, node count, workload count, running pods, GitOps health, alert count, and timestamp.
- Add CORS for `https://www.yesidlopez.de` and short in-process caching to avoid querying the API server on every request.

## Validation
- `kubectl kustomize apps/production/public-status-api`
- `kubectl kustomize apps/production`
- Extracted embedded `app.py` and verified with `python3 -m py_compile`