### PR TITLE
fix: update Multica images to v0.3.3

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -8,7 +8,7 @@ data:
     backend:
       replicaCount: 1
       image:
-        tag: v0.3.1
+        tag: v0.3.3
       resources:
         requests:
           cpu: 100m
@@ -33,7 +33,7 @@ data:
     frontend:
       replicaCount: 1
       image:
-        tag: v0.3.1
+        tag: v0.3.3
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Problem
Multica is currently deployed with image tags `v0.3.1` while the latest upstream release is `v0.3.3`.

## Root cause
The Helm chart repository only publishes chart `0.2.29`, so there is no chart `0.3.3` to upgrade to. The application images for `v0.3.3` are available in GHCR.

## Fix
Update only the backend and frontend image tags in the Multica Helm values from `v0.3.1` to `v0.3.3`, keeping the Helm chart pinned at `0.2.29`.

Pre-checks:
- `ghcr.io/multica-ai/multica-backend:v0.3.3` exists
- `ghcr.io/multica-ai/multica-web:v0.3.3` exists
- CNPG Postgres backups are completing successfully

Post-merge checks:
- verify `multica-backend` and `multica-frontend` roll out successfully
- check backend/frontend logs for migration or auth/session errors
- verify login, issues, websocket/runtime, and uploads/previews
