### PR TITLE
feat(minio): add multica-uploads bucket and include in mirror backup

### DIFF
--- a/infrastructure/controllers/minio/configmap-helm-values.yaml
+++ b/infrastructure/controllers/minio/configmap-helm-values.yaml
@@ -35,11 +35,14 @@ data:
     buckets:
       # payload-media is fronted by the media.luloai.com ingress and serves
       # public assets (case-study mockups, etc.) directly to the landing site.
-      # Only this bucket is public — postgres-backups stays private.
+      # Only this bucket is public — others stay private.
       - name: payload-media
         policy: download
         purge: false
       - name: postgres-backups
+        policy: none
+        purge: false
+      - name: multica-uploads
         policy: none
         purge: false
     metrics:

--- a/infrastructure/controllers/minio/cronjob-backup.yaml
+++ b/infrastructure/controllers/minio/cronjob-backup.yaml
@@ -36,7 +36,7 @@ spec:
                   mc alias set local http://minio.minio.svc.cluster.local:9000 \
                     "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
                   mkdir -p /mnt/mc-mirror
-                  for bucket in payload-media postgres-backups; do
+                  for bucket in payload-media postgres-backups multica-uploads; do
                     echo "[$(date -Iseconds)] mirroring $bucket"
                     mc mirror --overwrite --remove \
                       "local/$bucket" "/mnt/mc-mirror/$bucket"


### PR DESCRIPTION
## Summary
- Add a private `multica-uploads` bucket to the MinIO chart values (`policy: none`).
- Extend the `minio-mirror-backup` CronJob to mirror it to NFS every 6h, alongside `payload-media` and `postgres-backups`.

## Why
This lands the storage destination **before** Multica is switched from its Longhorn PVC to S3 (follow-up PR). Splitting the change keeps each step independently verifiable: the bucket exists and is in the backup rotation by the time Multica points at it.

## Test plan
- [ ] Flux reconciles `infra-controllers`; the MinIO `helm install/upgrade` post-hook creates the new bucket.
- [ ] `kubectl -n minio exec -it deploy/minio -- mc ls local/` shows `multica-uploads/` alongside the other two.
- [ ] Manually trigger the cronjob (`kubectl -n minio create job --from=cronjob/minio-mirror-backup mirror-test`) and confirm it iterates over all three buckets and exits cleanly (the new bucket is empty so its mirror is a no-op).

## Follow-up
After this merges and the bucket exists, run a one-shot migration Job (not in git) to copy data from the `multica-uploads` PVC to the bucket, then open the follow-up PR that switches Multica's chart values to use S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)