### PR TITLE
feat(multica): move uploads to MinIO bucket; drop Longhorn PVC

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -15,12 +15,6 @@ data:
           memory: 128Mi
         limits:
           memory: 512Mi
-      # Required so the uploads PVC is chgrp'd to gid 1000 on mount —
-      # otherwise the non-root backend (runAsUser/Group 1000) gets EACCES
-      # creating subdirectories under /app/data/uploads.
-      podSecurityContext:
-        fsGroup: 1000
-        fsGroupChangePolicy: OnRootMismatch
       extraEnv:
         - name: GITHUB_APP_SLUG
           value: "multica-luloai"
@@ -29,6 +23,22 @@ data:
             secretKeyRef:
               name: multica-app-secrets
               key: githubWebhookSecret
+        - name: S3_BUCKET
+          value: "multica-uploads"
+        - name: S3_REGION
+          value: "us-east-1"
+        - name: AWS_ENDPOINT_URL
+          value: "http://minio.minio.svc.cluster.local:9000"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: minio-backup-credentials
+              key: ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-backup-credentials
+              key: ACCESS_SECRET_KEY
 
     frontend:
       replicaCount: 1
@@ -54,11 +64,7 @@ data:
       create: true
 
     persistence:
-      enabled: true
-      storageClass: longhorn
-      size: 10Gi
-      accessModes:
-        - ReadWriteOnce
+      enabled: false
 
     ingress:
       enabled: true

--- a/apps/production/multica/helmrelease.yaml
+++ b/apps/production/multica/helmrelease.yaml
@@ -35,23 +35,3 @@ spec:
       valuesKey: googleClientSecret
       targetPath: config.googleClientSecret
       optional: true
-  postRenderers:
-    # Opt the uploads PVC into Longhorn's `backup` RecurringJob group.
-    # Longhorn syncs recurring-job-group labels from PVC to Volume only when
-    # the PVC also carries `recurring-job.longhorn.io/source=enabled`.
-    # TODO: remove once sshine/multica-helm#2 (persistence.labels) is
-    # released and we bump the chart. Then move both labels into
-    # configmap-helm-values.yaml under persistence.labels.
-    - kustomize:
-        patches:
-          - target:
-              version: v1
-              kind: PersistentVolumeClaim
-              name: multica-uploads
-            patch: |
-              - op: add
-                path: /metadata/labels/recurring-job.longhorn.io~1source
-                value: enabled
-              - op: add
-                path: /metadata/labels/recurring-job-group.longhorn.io~1backup
-                value: enabled


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE YET.** Blocked on:
> 1. #104 (bucket + backup) merged and reconciled.
> 2. One-shot migration Job has copied existing PVC contents to `multica-uploads`.

## Summary
Switch the Multica backend from the Longhorn-backed `/app/data/uploads` PVC to the in-cluster MinIO bucket `multica-uploads`. Backups now ride the existing `minio-mirror-backup` CronJob to NFS instead of Longhorn RecurringJobs.

## Changes
- `extraEnv`: add `S3_BUCKET`, `S3_REGION=us-east-1`, `AWS_ENDPOINT_URL=http://minio.minio.svc.cluster.local:9000`, and `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the existing `minio-backup-credentials` SealedSecret (same one CNPG uses in this namespace).
- `persistence.enabled: false` — chart stops provisioning a PVC.
- Drop `backend.podSecurityContext.fsGroup` (only mattered for PVC writes).
- Drop the `postRenderers` kustomize patch that added Longhorn recurring-job labels to the PVC. The bucket-mirror backup replaces it.

## Why
The old setup required:
1. A `fsGroup: 1000` to make the PVC writable by the non-root backend.
2. A postRenderer to add `recurring-job.longhorn.io/source` + `recurring-job-group.longhorn.io/backup` labels onto the rendered PVC (chart didn't expose `persistence.labels` — `sshine/multica-helm#2`).

Switching to S3-on-MinIO eliminates both. The bucket already lives in the existing mirror-to-NFS backup rotation.

## Test plan
- [ ] #104 merged; bucket exists (`mc ls local/multica-uploads`).
- [ ] One-shot migration Job has copied existing uploads to the bucket (verified by `mc ls --recursive`).
- [ ] After merge, `kubectl -n multica get pod` shows the backend rolling out cleanly (no PVC mount).
- [ ] Create a workspace, attach a file, confirm the object lands in MinIO and is served back via the app.
- [ ] Existing workspaces still resolve their old attachments.
- [ ] Manual cleanup: `kubectl -n multica delete pvc multica-uploads` once everything is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)