### PR TITLE
feat(minio): expose multica-uploads bucket at media.multica.yesidlopez.de

### DIFF
--- a/infrastructure/controllers/minio/configmap-helm-values.yaml
+++ b/infrastructure/controllers/minio/configmap-helm-values.yaml
@@ -35,15 +35,19 @@ data:
     buckets:
       # payload-media is fronted by the media.luloai.com ingress and serves
       # public assets (case-study mockups, etc.) directly to the landing site.
-      # Only this bucket is public — others stay private.
       - name: payload-media
         policy: download
         purge: false
+      # postgres-backups stays private — only CNPG / backup tooling reads it.
       - name: postgres-backups
         policy: none
         purge: false
+      # multica-uploads is fronted by the media.multica.yesidlopez.de ingress.
+      # Public because Multica's S3-backed storage has no presigned-URL or
+      # backend-proxy path upstream yet (multica-ai/multica#2804, PR #2740);
+      # protection relies on UUID-only keys (workspaces/<uuid>/<uuid>.png).
       - name: multica-uploads
-        policy: none
+        policy: download
         purge: false
     metrics:
       serviceMonitor:

--- a/infrastructure/controllers/minio/ingress-multica-uploads.yaml
+++ b/infrastructure/controllers/minio/ingress-multica-uploads.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-multica-uploads-ingress
+  namespace: minio
+  annotations:
+    cert-manager.io/cluster-issuer: acme-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.yesidlopez.de
+    # Rewrite /<key> to /multica-uploads/<key> before forwarding to MinIO so
+    # Multica can publish bucket-agnostic URLs via CLOUDFRONT_DOMAIN.
+    nginx.ingress.kubernetes.io/rewrite-target: /multica-uploads/$1
+    # MinIO streams object bodies; disable size cap and let large GETs through.
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "180"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - media.multica.yesidlopez.de
+      secretName: minio-multica-uploads-tls
+  rules:
+    - host: media.multica.yesidlopez.de
+      http:
+        paths:
+          - path: /(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000

--- a/infrastructure/controllers/minio/kustomization.yaml
+++ b/infrastructure/controllers/minio/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - sealed-minio-credentials.yaml
   - cronjob-backup.yaml
   - ingress.yaml
+  - ingress-multica-uploads.yaml


### PR DESCRIPTION
## Summary
- Flip `multica-uploads` bucket from `policy: none` to `policy: download` (public read).
- Add a new ingress at `media.multica.yesidlopez.de` that rewrites `/<key>` to `/multica-uploads/<key>` before forwarding to MinIO, so Multica can publish bucket-agnostic URLs via `CLOUDFRONT_DOMAIN`.

## Why public
Multica's S3-backed storage has no presigned-URL or backend-proxy path in upstream today:
- Issue: [multica-ai/multica#2804](https://github.com/multica-ai/multica/issues/2804) — \`/uploads/*\` only supports local storage.
- PR: [multica-ai/multica#2740](https://github.com/multica-ai/multica/pull/2740) — adds the S3 proxy. Open, CI passing, awaiting review (commented to nudge).

Until that lands and ships in a release, the only way to make uploads load in the browser is to expose the bucket publicly. Same UUID-keys-only protection model already in use for \`payload-media\` (lulo-cms).

Once #2740 ships, we can flip this bucket back to \`policy: none\` and drop this ingress in favor of routing via \`multica.yesidlopez.de/uploads/*\`.

## Test plan
- [ ] Flux reconciles \`infra-controllers\`.
- [ ] MinIO chart sync updates the bucket policy: \`kubectl -n minio exec deploy/minio -- mc anonymous get local/multica-uploads\` → \`Access permission for \`local/multica-uploads\` is \`download\`\`.
- [ ] Cert issued: \`kubectl -n minio get cert minio-multica-uploads-tls\` → Ready.
- [ ] External-DNS creates A record for \`media.multica.yesidlopez.de\` pointing to \`homelab.yesidlopez.de\`.
- [ ] Curl from the public internet: \`curl -I https://media.multica.yesidlopez.de/workspaces/89b6c921-e68f-4e54-bc3c-d86eb24eb770/019e36a7-6eea-7c8e-b71c-9e800313a115.png\` → 200 OK (file pre-migrated).

## Follow-up PR
Wires \`CLOUDFRONT_DOMAIN: media.multica.yesidlopez.de\` into Multica's HelmRelease — must be merged after this one is reconciled and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)