### PR TITLE
feat(multica): set CLOUDFRONT_DOMAIN so attachment URLs are browser-resolvable

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -39,6 +39,14 @@ data:
             secretKeyRef:
               name: minio-backup-credentials
               key: ACCESS_SECRET_KEY
+        # Public reader host for attachments. AWS_ENDPOINT_URL above stays
+        # in-cluster for SDK uploads; this overrides the host written into
+        # attachment URLs so browsers resolve them through the public
+        # `media.multica.yesidlopez.de` ingress. Remove once
+        # multica-ai/multica#2740 ships and the backend can proxy `/uploads/*`
+        # from S3 directly.
+        - name: CLOUDFRONT_DOMAIN
+          value: "media.multica.yesidlopez.de"
 
     frontend:
       replicaCount: 1


### PR DESCRIPTION
> ⚠️ **DRAFT — DO NOT MERGE YET.** Blocked on:
> 1. #106 (bucket public + ingress) merged and reconciled.
> 2. Curl smoke test against \`https://media.multica.yesidlopez.de/<existing-key>\` returns 200.

## Summary
Add \`CLOUDFRONT_DOMAIN=media.multica.yesidlopez.de\` to the Multica backend so attachment URLs written into the DB resolve in the browser.

## Why
Without this, \`S3Storage.uploadedURL()\` falls into the \`AWS_ENDPOINT_URL\` branch (see [\`server/internal/storage/s3.go:226-238\`](https://github.com/multica-ai/multica/blob/main/server/internal/storage/s3.go#L226-L238)) and writes URLs like \`http://minio.minio.svc.cluster.local:9000/multica-uploads/<key>\` — only resolvable in-cluster. Setting \`CLOUDFRONT_DOMAIN\` flips the URL to \`https://<cdn>/<key>\`, which the new public ingress in #106 maps to the bucket via path rewrite.

\`AWS_ENDPOINT_URL\` stays in-cluster — SDK uploads still write through \`minio.minio.svc.cluster.local:9000\`. Only the reader-facing URL changes, exactly as documented in [\`SELF_HOSTING_ADVANCED.md\`](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING_ADVANCED.md#file-storage-optional) and the comment in s3.go.

## Followup once #106 + this are reconciled
- DB cleanup: existing attachment rows still hold the broken URLs (4 with the local-storage \`/uploads/...\` shape from before the migration, 1 with the broken \`http://minio.minio.svc...\` shape from after). Will be fixed by a one-shot SQL UPDATE (not in git), or by re-uploading the affected files.
- Once [multica-ai/multica#2740](https://github.com/multica-ai/multica/pull/2740) ships, remove this var and the public ingress + bucket-policy in #106, route uploads via \`multica.yesidlopez.de/uploads/*\` instead.

## Test plan
- [ ] #106 merged and reconciled, smoke test against the ingress returns 200.
- [ ] After merge, \`kubectl -n multica describe deploy/multica-backend\` shows \`CLOUDFRONT_DOMAIN: media.multica.yesidlopez.de\` in env.
- [ ] Upload a new image in a workspace, confirm the URL in the response is \`https://media.multica.yesidlopez.de/workspaces/.../<file>.png\` and renders in the browser.
- [ ] Backend logs show \`S3 storage initialized\` with the new \`cdn_domain\` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)