### PR TITLE
feat(public-status-api): allow multiple CORS origins

### DIFF
--- a/apps/production/public-status-api/configmap.yaml
+++ b/apps/production/public-status-api/configmap.yaml
@@ -24,7 +24,13 @@ data:
 
     PORT = int(os.environ.get("PORT", "8080"))
     CACHE_TTL_SECONDS = int(os.environ.get("CACHE_TTL_SECONDS", "30"))
-    CORS_ALLOW_ORIGIN = os.environ.get("CORS_ALLOW_ORIGIN", "https://www.yesidlopez.de")
+    ALLOWED_ORIGINS = [
+        origin.strip()
+        for origin in os.environ.get(
+            "CORS_ALLOW_ORIGIN", "https://www.yesidlopez.de"
+        ).split(",")
+        if origin.strip()
+    ]
     API_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
     API_PORT = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
     API_BASE = f"https://{API_HOST}:{API_PORT}"
@@ -213,7 +219,12 @@ data:
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(body)))
             self.send_header("Cache-Control", "public, max-age=30")
-            self.send_header("Access-Control-Allow-Origin", CORS_ALLOW_ORIGIN)
+            request_origin = self.headers.get("Origin")
+            if request_origin in ALLOWED_ORIGINS:
+                self.send_header("Access-Control-Allow-Origin", request_origin)
+                self.send_header("Vary", "Origin")
+            elif ALLOWED_ORIGINS:
+                self.send_header("Access-Control-Allow-Origin", ALLOWED_ORIGINS[0])
             self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
             self.send_header("Access-Control-Allow-Headers", "Content-Type")
             self.end_headers()

--- a/apps/production/public-status-api/deployment.yaml
+++ b/apps/production/public-status-api/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: CACHE_TTL_SECONDS
               value: "30"
             - name: CORS_ALLOW_ORIGIN
-              value: "https://www.yesidlopez.de"
+              value: "https://www.yesidlopez.de,https://lab.yesidlopez.de"
           volumeMounts:
             - name: app
               mountPath: /app


### PR DESCRIPTION
## Problem
\`CORS_ALLOW_ORIGIN\` only accepts a single origin and is hardcoded to \`https://www.yesidlopez.de\`. The new \`lab.yesidlopez.de\` frontend can't call the status API.

## Fix
- Parse \`CORS_ALLOW_ORIGIN\` as a comma-separated list of allowed origins.
- On each response, look at the request's \`Origin\` header and echo it if it matches one of the allowed origins (with \`Vary: Origin\` so caches don't mix them up).
- Fall back to the first allowed origin if the request didn't match — keeps the header well-formed for direct probes and \`curl\` without breaking the contract for the matched browsers.
- Default value bumped to \`https://www.yesidlopez.de,https://lab.yesidlopez.de\` so both frontends work out of the box.

## Validation
- \`kubectl kustomize apps/production/public-status-api\`
- \`python3 compile()\` on the extracted \`app.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)