### PR TITLE
chore(alloy): drop stale langfuse namespace references

### DIFF
--- a/infrastructure/controllers/alloy/configmap-helm-values.yaml
+++ b/infrastructure/controllers/alloy/configmap-helm-values.yaml
@@ -27,10 +27,10 @@ data:
           discovery.kubernetes "pods" {
             role = "pod"
             namespaces {
-              names = ["resumelo", "resumelo-dev", "langfuse", "umami", "macondo"]
+              names = ["resumelo", "resumelo-dev", "umami", "macondo"]
             }
           }
-          
+
           // Relabel to use pod name as service
           discovery.relabel "kubernetes_pods" {
             targets = discovery.kubernetes.pods.targets
@@ -73,10 +73,10 @@ data:
           discovery.kubernetes "services" {
             role = "service"
             namespaces {
-              names = ["resumelo", "resumelo-dev", "langfuse", "umami", "macondo"]
+              names = ["resumelo", "resumelo-dev", "umami", "macondo"]
             }
           }
-          
+
           // Scrape metrics from services with prometheus.io annotations
           discovery.relabel "prometheus_services" {
             targets = discovery.kubernetes.services.targets


### PR DESCRIPTION
## Summary

Closes the last leftover from #20. The langfuse application was removed in `f5e513b`, and earlier cleanup already dropped `ml-portfolio` and `test-app`. Alloy was still listing the `langfuse` namespace in its `discovery.kubernetes` blocks — that namespace no longer exists, so the entry was dead config.

## Scope

- `infrastructure/controllers/alloy/configmap-helm-values.yaml` — remove `langfuse` from both the pod-discovery and service-discovery namespace lists.

## Notes on the rest of #20

- `apps/production/langfuse/` directory: not present in the repo. `langfuse-secrets.yaml` exists only locally because `.gitignore` excludes `*secret*` patterns — nothing to clean up in git.
- `apps/production/ml-portfolio/`, `apps/production/test-app/`: already removed in earlier commits.
- `tayrona` / `macondo` are commented out in `apps/production/kustomization.yaml` but their directories remain and `macondo` is still referenced in alloy — leaving as-is because that decision is separate from #20.

## Related

- Closes #20
- #15 (Loki cert-manager annotation) is also obsolete: commit `daf549c` disabled the public Loki ingress; the original issue noted "if Loki's public ingress is removed entirely, this issue becomes moot". Closing that one separately with a comment — no code change needed.

## Test plan

- [ ] Flux reconciles the alloy HelmRelease without errors
- [ ] `kubectl logs -n monitoring -l app.kubernetes.io/name=alloy` shows no errors about the removed namespace
- [ ] Logs from `resumelo`, `umami`, `macondo` still arrive in Loki (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)