### PR TITLE
chore: pin mutable image tags to specific versions

### DIFF
--- a/apps/production/ddns-updater/deployment.yaml
+++ b/apps/production/ddns-updater/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ddns
-          image: qmcgaw/ddns-updater:latest
+          image: qmcgaw/ddns-updater:v2.10.0
           envFrom:
             - secretRef:
                 name: ddns-updater-config

--- a/apps/production/docker-registry/ui/configmap-helm-values.yaml
+++ b/apps/production/docker-registry/ui/configmap-helm-values.yaml
@@ -12,7 +12,7 @@ data:
       deleteImages: true
       registrySecured: true
       singleRegistry: true
-      image: "joxit/docker-registry-ui:latest"
+      image: "joxit/docker-registry-ui:2.6.0"
       resources:
         requests:
           memory: "64Mi"

--- a/infrastructure/controllers/external-dns/configmap-helm-values.yaml
+++ b/infrastructure/controllers/external-dns/configmap-helm-values.yaml
@@ -50,8 +50,8 @@ data:
     # Sidecar container for Porkbun webhook provider
     sidecars:
       - name: external-dns-webhook-provider
-        image: ghcr.io/konnektr-io/external-dns-porkbun-webhook:main
-        imagePullPolicy: Always
+        image: ghcr.io/konnektr-io/external-dns-porkbun-webhook:v0.2.19
+        imagePullPolicy: IfNotPresent
         args:
         - --domain-filter=yesidlopez.de
         - --domain-filter=resumelo.me


### PR DESCRIPTION
## Summary

Three workloads were running on mutable Docker tags (`:latest` and `:main`), making deployments non-reproducible and exposing the cluster to silent breaking changes on pod restart. Pinning to explicit versions locks the running image and lets Renovate (`config:recommended` in `renovate.json`) track upstream releases so bumps come through reviewable PRs.

## Changes

| Workload | Before | After | Notes |
|---|---|---|---|
| `ddns-updater` | `qmcgaw/ddns-updater:latest` | `qmcgaw/ddns-updater:v2.10.0` | `:latest` digest is slightly ahead of `v2.10.0` (likely an untagged build); pinning to v2.10.0 lands on the most recent stable release. |
| `docker-registry-ui` | `joxit/docker-registry-ui:latest` | `joxit/docker-registry-ui:2.6.0` | `:latest` already resolved to `2.6.0` (same digest), so this is a no-op pull. |
| `external-dns-porkbun-webhook` | `ghcr.io/konnektr-io/external-dns-porkbun-webhook:main` + `imagePullPolicy: Always` | `v0.2.19` + `imagePullPolicy: IfNotPresent` | Was tracking the `main` branch HEAD. `v0.2.19` is the latest tagged release. `Always` only made sense with a mutable tag; with a pinned semver tag `IfNotPresent` is correct (avoids unnecessary registry pulls on every restart). |

## Test plan

After merge + Flux reconcile:

- [ ] `kubectl get pods -n ddns-updater -o jsonpath='{.items[*].spec.containers[*].image}'` shows `qmcgaw/ddns-updater:v2.10.0`
- [ ] `kubectl get pods -n registry -o jsonpath='{.items[*].spec.containers[*].image}'` shows `joxit/docker-registry-ui:2.6.0`
- [ ] `kubectl get pods -n external-dns -o jsonpath='{.items[*].spec.containers[*].image}'` shows the webhook sidecar at `v0.2.19`
- [ ] DDNS still updating (check `qmcgaw/ddns-updater` logs for successful update lines)
- [ ] External-DNS still reconciling Porkbun records (check `external-dns` controller logs for successful Porkbun calls)
- [ ] Docker registry UI still loads at its ingress URL

## Follow-up

Renovate will start tracking these images on the next run. Bumps will arrive as PRs grouped per `renovate.json` schedule.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)