### PR TITLE
chore(flux): label valuesFrom sources for immediate Helm reconcile

### DIFF
--- a/apps/production/docker-registry/configmap-helm-values.yaml
+++ b/apps/production/docker-registry/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: docker-registry-helm-chart-value-overrides
   namespace: registry
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     persistence:

--- a/apps/production/docker-registry/sealed-docker-registry-helm-values.yaml
+++ b/apps/production/docker-registry/sealed-docker-registry-helm-values.yaml
@@ -11,4 +11,6 @@ spec:
     metadata:
       name: docker-registry-helm-values
       namespace: registry
+      labels:
+        reconcile.fluxcd.io/watch: "Enabled"
     type: Opaque

--- a/apps/production/docker-registry/ui/configmap-helm-values.yaml
+++ b/apps/production/docker-registry/ui/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: docker-registry-ui-helm-chart-value-overrides
   namespace: registry
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     ui:

--- a/apps/production/gotenberg/configmap-helm-values.yaml
+++ b/apps/production/gotenberg/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: gotenberg-helm-chart-value-overrides
   namespace: resumelo
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     securityContext:

--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: multica-helm-chart-value-overrides
   namespace: multica
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     backend:

--- a/apps/production/n8n/configmap-helm-values.yaml
+++ b/apps/production/n8n/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: n8n-helm-chart-value-overrides
   namespace: n8n
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     image:

--- a/apps/production/umami/configmap-helm-values.yaml
+++ b/apps/production/umami/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: umami-helm-chart-value-overrides
   namespace: umami
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     replicaCount: 1

--- a/infrastructure/controllers/alloy/configmap-helm-values.yaml
+++ b/infrastructure/controllers/alloy/configmap-helm-values.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: alloy-helm-chart-value-overrides
   namespace: alloy
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     alloy:

--- a/infrastructure/controllers/cert-manager-porkbun-webhook/configmap-helm-values.yaml
+++ b/infrastructure/controllers/cert-manager-porkbun-webhook/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: porkbun-webhook-helm-chart-value-overrides
   namespace: cert-manager
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     # Resource limits and requests

--- a/infrastructure/controllers/cert-manager/configmap-helm-values.yaml
+++ b/infrastructure/controllers/cert-manager/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: cert-manager-helm-chart-value-overrides
   namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     crds:

--- a/infrastructure/controllers/cloudnative-pg/configmap-helm-values.yaml
+++ b/infrastructure/controllers/cloudnative-pg/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: cloudnative-pg-helm-chart-value-overrides
   namespace: cnpg-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     # CloudNative PG operator configuration

--- a/infrastructure/controllers/external-dns/configmap-helm-values.yaml
+++ b/infrastructure/controllers/external-dns/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: external-dns-helm-chart-value-overrides
   namespace: external-dns
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     # Use upstream image — Bitnami removed images from docker.io

--- a/infrastructure/controllers/flux-operator-mcp/configmap-helm-values.yaml
+++ b/infrastructure/controllers/flux-operator-mcp/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: flux-operator-mcp-helm-chart-value-overrides
   namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     transport: http

--- a/infrastructure/controllers/grafana/configmap-helm-values.yaml
+++ b/infrastructure/controllers/grafana/configmap-helm-values.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: grafana-helm-chart-value-overrides
   namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     deploymentStrategy:

--- a/infrastructure/controllers/grafana/sealed-grafana-secrets.yaml
+++ b/infrastructure/controllers/grafana/sealed-grafana-secrets.yaml
@@ -11,4 +11,6 @@ spec:
     metadata:
       name: grafana-admin-credentials
       namespace: flux-system
+      labels:
+        reconcile.fluxcd.io/watch: "Enabled"
     type: Opaque

--- a/infrastructure/controllers/loki/configmap-helm-values.yaml
+++ b/infrastructure/controllers/loki/configmap-helm-values.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: loki-helm-chart-value-overrides
   namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     deploymentMode: SingleBinary

--- a/infrastructure/controllers/longhorn/configmap-helm-values.yaml
+++ b/infrastructure/controllers/longhorn/configmap-helm-values.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: longhorn-values
   namespace: longhorn-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     metrics:

--- a/infrastructure/controllers/minio/configmap-helm-values.yaml
+++ b/infrastructure/controllers/minio/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: minio-helm-chart-value-overrides
   namespace: minio
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     mode: standalone

--- a/infrastructure/controllers/nginx-ingress-controller/configmap-helm-values.yaml
+++ b/infrastructure/controllers/nginx-ingress-controller/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: nginx-ingress-controller-helm-chart-value-overrides
   namespace: nginx-ingress-controller
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |-
     controller:

--- a/infrastructure/controllers/plugin-barman-cloud/configmap-helm-values.yaml
+++ b/infrastructure/controllers/plugin-barman-cloud/configmap-helm-values.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: plugin-barman-cloud-helm-chart-value-overrides
   namespace: cnpg-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     resources:

--- a/infrastructure/controllers/prometheus/configmap-helm-values.yaml
+++ b/infrastructure/controllers/prometheus/configmap-helm-values.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: prometheus-helm-chart-value-overrides
   namespace: flux-system
+  labels:
+    reconcile.fluxcd.io/watch: "Enabled"
 data:
   values.yaml: |
     prometheus:


### PR DESCRIPTION
## Summary

Every HelmRelease in the repo pulls its values from a ConfigMap (and, in two cases, a SealedSecret) via `spec.valuesFrom`. Without the `reconcile.fluxcd.io/watch: "Enabled"` label, helm-controller does not watch those sources — values edits land in the cluster via the apps/infra Kustomization but the corresponding HelmRelease keeps running the old rendered chart until the next interval reconciliation kicks in (or someone runs `flux reconcile helmrelease ...` manually).

We hit this on PR #114 (image tag pinning): the ConfigMaps got updated but `docker-registry-ui` and `external-dns` kept their old pods until a manual reconcile. Labeling the sources eliminates that gap permanently.

## Validation

Pattern verified against the official upstream specs (not inferred):

- **Flux helm-controller** — `fluxcd/helm-controller/docs/spec/v2/helmreleases.md`:
  > Secret or ConfigMap:
  > ```yaml
  > metadata:
  >   labels:
  >     reconcile.fluxcd.io/watch: Enabled
  > ```
- **Sealed-secrets** — bitnami-labs README confirms that `spec.template.metadata.labels` is propagated as-is to the unsealed Secret, so the label still reaches helm-controller through that indirection.

## Scope

- **19 ConfigMaps** — every `*-helm-chart-value-overrides` plus `longhorn-values`. Label inserted under `metadata.labels` right after `namespace`.
- **2 SealedSecrets** used as values inputs (`grafana-admin-credentials`, `docker-registry-helm-values`). Label inserted under `spec.template.metadata.labels` so it propagates to the unsealed Secret.

Diff is uniform: 21 files, 42 insertions, 0 deletions.

## Out of scope

- CNPG-managed `*-postgres-app` Secrets (`umami`, `multica`, `n8n`) are auto-generated by CloudNativePG and rarely change after initial provisioning. If we ever want them watched, the way in is `inheritedMetadata.labels` on the CNPG Cluster spec — not in scope here.
- `substituteFrom` (Kustomization postBuild) — not used anywhere in this repo.

## Expected behavior post-merge

- Adding labels themselves does not change rendered chart values, so helm-controller should not perform a meaningful upgrade on any release — events should show "no changes" or skip the upgrade.
- After merge, editing any values ConfigMap will trigger the corresponding HelmRelease to reconcile within seconds instead of waiting for the next interval tick.

## Test plan

- [ ] Flux applies the Kustomizations without errors
- [ ] `flux get hr -A` shows all releases `Ready=True` post-merge (no spurious upgrade failures)
- [ ] Smoke test: edit a trivial values key in one ConfigMap (e.g. a comment), commit, and confirm `flux get hr` shows reconciliation within ~30s without needing manual `flux reconcile helmrelease`
- [ ] `kubectl get cm -n flux-system loki-helm-chart-value-overrides --show-labels` confirms the label landed

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)