### PR TITLE
chore(flux): pin Helm chart versions to currently deployed releases

### DIFF
--- a/apps/production/gotenberg/helmrelease.yaml
+++ b/apps/production/gotenberg/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: gotenberg
-      version: ">=1.0.0"
+      version: 1.21.0
       sourceRef:
         kind: HelmRepository
         name: maikumori

--- a/infrastructure/controllers/cloudnative-pg/helmrelease.yaml
+++ b/infrastructure/controllers/cloudnative-pg/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: cloudnative-pg
-      version: ">=0.21.0"
+      version: 0.28.2
       sourceRef:
         kind: HelmRepository
         name: cnpg

--- a/infrastructure/controllers/loki/helmrelease.yaml
+++ b/infrastructure/controllers/loki/helmrelease.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: loki
+      version: 7.0.0
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository

--- a/infrastructure/controllers/plugin-barman-cloud/helmrelease.yaml
+++ b/infrastructure/controllers/plugin-barman-cloud/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: plugin-barman-cloud
-      version: ">=0.6.0"
+      version: 0.6.0
       sourceRef:
         kind: HelmRepository
         name: cnpg

--- a/infrastructure/controllers/prometheus/helmrelease.yaml
+++ b/infrastructure/controllers/prometheus/helmrelease.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
+      version: 85.3.0
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository


### PR DESCRIPTION
## Summary

Five HelmReleases had open-ended version constraints — either a `>=` range or no `version:` field at all. Combined with the immediate-reconcile behavior introduced by #115, this meant any ConfigMap edit could trigger helm-controller to re-evaluate constraints against the latest HelmRepository index and silently upgrade a chart to a newer release.

Pinning to the exact versions currently running locks deployments to known-good releases. Renovate (`config:recommended` in `renovate.json`) keeps tracking upstream releases and opens PRs for bumps so upgrades come through reviewable commits.

## Changes

Each pin matches the chart version reported by `flux get hr -A` for the corresponding release:

| HelmRelease | Before | After | Role |
|---|---|---|---|
| `cloudnative-pg` | `>=0.21.0` | `0.28.2` | Postgres operator (runs all 4 CNPG clusters) |
| `plugin-barman-cloud` | `>=0.6.0` | `0.6.0` | WAL archiving to MinIO |
| `gotenberg` | `>=1.0.0` | `1.21.0` | PDF rendering used by resumelo |
| `kube-prometheus-stack` | _(no version field)_ | `85.3.0` | Monitoring stack |
| `loki` | _(no version field)_ | `7.0.0` | Log aggregation |

Diff: 5 files, 5 insertions, 3 deletions.

## Functional impact

**None.** Every pin equals the chart version already deployed. Helm will see no version change → no upgrade triggered → no rendered-manifest diff. The cluster state after merge is identical to the state before merge.

## Test plan

- [ ] After merge + Flux reconcile, `flux get hr -A` shows all five releases `Ready=True` with their existing revisions (no `.vN` bump from a spurious upgrade)
- [ ] `kubectl get pods -A` shows no restarts in `cnpg-system`, `prometheus`, `loki`, `resumelo` (gotenberg), or namespaces using CNPG-managed databases
- [ ] Renovate's next run picks up the pins and the Dependency Dashboard (#41) starts listing potential bumps for these charts

## Related

- Builds on #115 which made reconciles immediate (and thus amplified the drift risk this PR closes)
- Renovate config already exists in `renovate.json` — no changes needed there

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)