### PR TITLE
feat(monitoring): scrape Longhorn metrics and alert on block overhead

### DIFF
--- a/infrastructure/controllers/longhorn/kustomization.yaml
+++ b/infrastructure/controllers/longhorn/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - helmrepository.yaml
   - configmap-helm-values.yaml
+  - servicemonitor.yaml

--- a/infrastructure/controllers/longhorn/servicemonitor.yaml
+++ b/infrastructure/controllers/longhorn/servicemonitor.yaml
@@ -1,0 +1,24 @@
+---
+# The ServiceMonitor shipped by the Longhorn chart does not carry the
+# `release: kube-prometheus-stack` label that kube-prometheus-stack's
+# Prometheus uses to select scrape targets, so its metrics were never
+# being collected. This ServiceMonitor mirrors the upstream config but
+# adds the required label so Prometheus picks it up.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+  labels:
+    release: kube-prometheus-stack
+spec:
+  namespaceSelector:
+    matchNames:
+      - longhorn-system
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  endpoints:
+    - port: manager
+      interval: 30s
+      scrapeTimeout: 10s

--- a/infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml
+++ b/infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml
@@ -36,3 +36,24 @@ spec:
           annotations:
             summary: "PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} sobre 90%"
             description: "El PVC {{ $labels.persistentvolumeclaim }} en el namespace {{ $labels.namespace }} está al {{ $value | printf \"%.1f\" }}% de uso. Riesgo inminente de llenarse."
+
+    - name: longhorn.usage
+      rules:
+        # Detects when Longhorn's block-level accounting (actualSize) exceeds
+        # the declared volume capacity. This is a leading indicator of
+        # orphan snapshots, missed TRIM commands, or thin-provisioning
+        # accumulation — none of which show up in the filesystem-level
+        # alerts above (kubelet_volume_stats_*).
+        - alert: LonghornVolumeBlockOverhead
+          expr: |
+            (
+              longhorn_volume_actual_size_bytes
+              / on(volume) group_left() longhorn_volume_capacity_bytes
+            ) > 1.1
+          for: 30m
+          labels:
+            severity: warning
+            scope: storage
+          annotations:
+            summary: "Volumen Longhorn {{ $labels.volume }} con bloques sobre el 110% del declarado"
+            description: "El volumen {{ $labels.volume }} reporta actualSize al {{ $value | printf \"%.0f\" }}x del capacity declarado. Suele indicar snapshots huérfanos o falta de TRIM. Revisar con kubectl get snapshots.longhorn.io."


### PR DESCRIPTION
## Context

Today we discovered the Prometheus volume reporting **120% of declared capacity** in Longhorn's `actualSize`, due to a 13-day-old orphan snapshot from a previous volume expansion. The filesystem itself was at only 28% — well below the existing alert thresholds — so nothing fired and the situation went unnoticed.

Investigation surfaced two issues:

1. **Longhorn metrics weren't being scraped at all.** The chart ships a ServiceMonitor named `longhorn-prometheus-servicemonitor`, but it carries Helm-default labels and lacks the `release: kube-prometheus-stack` label that this cluster's `Prometheus` uses to select ServiceMonitors. So `longhorn_volume_actual_size_bytes`, `longhorn_volume_capacity_bytes`, and every other `longhorn_*` series had **0 samples in Prometheus**.
2. **No alert covered block-level overhead.** The existing `PersistentVolumeUsageHigh` / `Critical` rules in `volume-usage-rules.yaml` watch `kubelet_volume_stats_*` — i.e. filesystem usage. That's the right metric for "Prometheus is about to OOM-write", but it misses everything that happens between the filesystem and the underlying block storage (orphan snapshots, missed TRIM/discard, thin-provisioning accumulation).

## Changes

**`infrastructure/controllers/longhorn/servicemonitor.yaml`** (new file)
- ServiceMonitor with `release: kube-prometheus-stack` label so Prometheus selects it.
- Targets the same pod set (`app: longhorn-manager`) and port (`manager`) as the upstream Longhorn ServiceMonitor.
- 30s interval, 10s timeout — same defaults as kube-prometheus-stack ServiceMonitors.

**`infrastructure/controllers/longhorn/kustomization.yaml`**
- Adds `servicemonitor.yaml` to resources.

**`infrastructure/controllers/prometheus/alerts/volume-usage-rules.yaml`**
- New `longhorn.usage` group with one alert: `LonghornVolumeBlockOverhead`.
- Fires when `longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes > 1.1` for 30 minutes.
- Severity: warning, scope: storage — so it lands through the existing Discord-routed alerts.

## Test plan

After merge + Flux reconcile:

- [ ] `kubectl get servicemonitor -n longhorn-system` shows both the chart's and the new `longhorn` ServiceMonitor.
- [ ] Prometheus targets page (`/targets`) shows `longhorn-system/longhorn` as UP with 1–2 endpoints.
- [ ] `count(longhorn_volume_actual_size_bytes)` in Prometheus returns ≥1 (currently returns 0).
- [ ] Prometheus rules page (`/rules`) lists `LonghornVolumeBlockOverhead` under group `longhorn.usage`.
- [ ] `LonghornVolumeBlockOverhead` is `inactive` for all current volumes (we just purged the only one that would have triggered it).
- [ ] If you want to verify the alert wiring, you can temporarily lower the threshold (`> 1.0` instead of `> 1.1`) in a test branch and confirm a Discord message arrives, then revert.

## Notes

- The Longhorn chart's own ServiceMonitor stays in place; it's harmless without the right label. We don't try to relabel it because it's Helm-managed and would be reverted on chart upgrade. A dedicated, repo-owned ServiceMonitor is the durable fix.
- This adds one scrape target per `longhorn-manager` pod (one per node). The metrics payload is small; no meaningful Prometheus storage impact expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)