### PR TITLE
feat: add María Fernanda landing demo

### DIFF
--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - jenny-psiquiatra
   - mariana-toro
   - jenny-florez
+  - maria-fernanda-espana

--- a/apps/production/client-sites/maria-fernanda-espana/deployment.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+  labels:
+    app: maria-fernanda-espana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: maria-fernanda-espana
+  template:
+    metadata:
+      labels:
+        app: maria-fernanda-espana
+        name: maria-fernanda-espana
+    spec:
+      containers:
+      - name: maria-fernanda-espana
+        image: "registry.yesidlopez.de/maria-fernanda-espana:v1.0.1" # {"$imagepolicy": "lulo-demo-landings:maria-fernanda-espana"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/maria-fernanda-espana/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: maria-fernanda-espana
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/maria-fernanda-espana/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/maria-fernanda-espana
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/maria-fernanda-espana/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for maria-fernanda-espana
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/maria-fernanda-espana
+    strategy: Setters

--- a/apps/production/client-sites/maria-fernanda-espana/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/maria-fernanda-espana/ingress.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: maria-fernanda-espana-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "Demo Lulo AI"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - maria-fernanda-espana.demo.luloai.com
+      secretName: maria-fernanda-espana-tls
+  rules:
+    - host: maria-fernanda-espana.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: maria-fernanda-espana
+                port:
+                  number: 3000

--- a/apps/production/client-sites/maria-fernanda-espana/kustomization.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - sealed-basic-auth.yaml

--- a/apps/production/client-sites/maria-fernanda-espana/sealed-basic-auth.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/sealed-basic-auth.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: maria-fernanda-espana-basic-auth
+  namespace: lulo-demo-landings
+spec:
+  encryptedData:
+    auth: AgCBwc7gYkMLYOxRZvYXIWexpUE8WMOkxreDGlHkE0ZMW9LPohbOSNiYZXa4Qpc8wadx76vNdWZ36gr3MeoK3egF22bjNCDVbtGy3X6MUbYwMnPAymnofbXgb/wVt+qHyc6bVtnTYwnykaJhgE85kyIUtJEyx3I7E0B763F45M9oVZAy0RSrm25iXt5gWFfAO4ubhJLX0/Gthnx6dCWxPv+o+Qc4fidsNLAMvsjYgRsPArHf8rQa/21UfpjLqUFiZyh+g7Lsuo06U30izAAxS1jUOhhFeQ6kPS5EWfntrmhxBSb9SxlqVbSBuL5WMnpg/WPNvRAFBb32iJW1PsN0W3QI7BJN5nFVcMK8oA1yRBi/sPJqLY1wpuYDFikOSb6mck9pS/xgDwQbHr0HWhz/X7piuxf0jBzcGoncaidXEiiGq2003bPPeNKMIyvSLuePaceeC8bQtbe0rJwz34S7RASCe+Vy6oE1Bm6hvxnyOa6XmHBUk4gW0MUPjNw64YkHQ9xYUHAvI14cOZMext6nl8J4uTnNemB+5ZQiyFPO+tuhzpXNdjWHUz91mq+dVSJOMUlGMsoFgRiFYxtWhQbHQUkJ0j/M+VdYeY8WB3V8dR8YRVhtzwlw1kAyV96GMwFbsFWMIBJ3Q9ABimlKPEY53noUbxz4th4SB1H7uRjdUae9WapmusFcNwnuZvdJ1jfzOGBTpY5ZLmll+CaPhFc5ndYCFWoUjgxgGs0iPeRXvM/4jQvOnCi9/Uox+0GsGph9
+  template:
+    metadata:
+      name: maria-fernanda-espana-basic-auth
+      namespace: lulo-demo-landings
+    type: Opaque

--- a/apps/production/client-sites/maria-fernanda-espana/service.yaml
+++ b/apps/production/client-sites/maria-fernanda-espana/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: maria-fernanda-espana
+  name: maria-fernanda-espana
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: maria-fernanda-espana
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000


### PR DESCRIPTION
## Problem
The María Fernanda España landing was added to `yesid-lopez/luloai-client-sites`, but the homelab GitOps configuration did not include a demo deployment for it.

## Root cause
`apps/production/client-sites` already manages demo landings under `*.demo.luloai.com`, but `maria-fernanda-espana` was not listed there yet, so Flux would not create a Deployment/Service/Ingress or image automation for the new site.

## Fix
- Add `apps/production/client-sites/maria-fernanda-espana` using the existing client-sites pattern.
- Configure Deployment for `registry.yesidlopez.de/maria-fernanda-espana:v1.0.1`.
- Add Service, Ingress, TLS/external-dns annotations, basic-auth SealedSecret, and Flux image automation.
- Include the new client in `apps/production/client-sites/kustomization.yaml`.

## Validation
- Rendered successfully with:
  `kubectl kustomize apps/production/client-sites`

## Demo URL
After the client-sites PR is merged and its Docker image is built, Flux should serve:
`https://maria-fernanda-espana.demo.luloai.com`

Basic auth credentials were generated and shared with the owner out-of-band in chat.
