### PR TITLE
fix: update multica to v0.3.7

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -10,7 +10,7 @@ data:
     backend:
       replicaCount: 1
       image:
-        tag: v0.3.3
+        tag: v0.3.7
       resources:
         requests:
           cpu: 100m
@@ -53,7 +53,7 @@ data:
     frontend:
       replicaCount: 1
       image:
-        tag: v0.3.3
+        tag: v0.3.7
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Problem
Multica is currently pinned to image tag v0.3.3 in production values.

## Root cause
The backend and frontend image tags in apps/production/multica/configmap-helm-values.yaml have not been updated to the requested release.

## Fix
Updated both Multica backend and frontend image tags to v0.3.7 so Flux/Helm deploys the requested version.
