### PR TITLE
fix: increase Prometheus PVC size

### DIFF
--- a/infrastructure/controllers/prometheus/configmap-helm-values.yaml
+++ b/infrastructure/controllers/prometheus/configmap-helm-values.yaml
@@ -17,7 +17,7 @@ data:
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
-                  storage: 30Gi
+                  storage: 50Gi
         retention: 14d
         retentionSize: 24GB
         replicas: 1


### PR DESCRIPTION
## Problem
Longhorn triggered a volume usage alert for the Prometheus PVC because the Longhorn actual size was above the provisioned volume size.

Observed volume:
- Namespace: prometheus
- PVC: prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0
- Provisioned size: 30Gi
- Longhorn actual size: ~35.8GB / ~111%
- Longhorn state: attached, robustness: healthy

## Root cause
Prometheus is configured with retention: 14d and retentionSize: 24GB. With WAL, TSDB churn, and Longhorn snapshot/copy-on-write overhead, the 30Gi volume is too tight and can make Longhorn report actual usage above 100% even while the volume remains healthy.

## Fix
Increase the Prometheus Longhorn PVC request from 30Gi to 50Gi.

This gives Prometheus more headroom for the configured retention and Longhorn snapshot overhead, reducing the chance of recurring >100% Longhorn volume usage alerts.
