### PR TITLE
feat(client-sites): add Katerin Osorio

### DIFF
--- a/apps/production/client-sites/katerin-osorio/basic-auth.yaml
+++ b/apps/production/client-sites/katerin-osorio/basic-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: katerin-osorio-basic-auth
+  namespace: lulo-demo-landings
+type: Opaque
+data:
+  auth: a2F0ZXJpbjokMnkkMDUkNWNTMi54SDdLN3dEdUhpWGhncDAuT1FkcnV0RzdxaFliQnF5Y1l5TGFTSnZvL0NZVGN3ejIK

--- a/apps/production/client-sites/katerin-osorio/deployment.yaml
+++ b/apps/production/client-sites/katerin-osorio/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+  labels:
+    app: katerin-osorio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: katerin-osorio
+  template:
+    metadata:
+      labels:
+        app: katerin-osorio
+        name: katerin-osorio
+    spec:
+      containers:
+      - name: katerin-osorio
+        image: "registry.yesidlopez.de/katerin-osorio:v1.0.14" # {"$imagepolicy": "lulo-demo-landings:katerin-osorio"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/katerin-osorio/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/katerin-osorio/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: katerin-osorio
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/katerin-osorio/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/katerin-osorio/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/katerin-osorio
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/katerin-osorio/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/katerin-osorio/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for katerin-osorio
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/katerin-osorio
+    strategy: Setters

--- a/apps/production/client-sites/katerin-osorio/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/katerin-osorio/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/katerin-osorio/ingress.yaml
+++ b/apps/production/client-sites/katerin-osorio/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: katerin-osorio-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "Demo Lulo AI"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - katerin-osorio.demo.luloai.com
+      secretName: katerin-osorio-tls
+  rules:
+    - host: katerin-osorio.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: katerin-osorio
+                port:
+                  number: 3000

--- a/apps/production/client-sites/katerin-osorio/kustomization.yaml
+++ b/apps/production/client-sites/katerin-osorio/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - basic-auth.yaml

--- a/apps/production/client-sites/katerin-osorio/service.yaml
+++ b/apps/production/client-sites/katerin-osorio/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: katerin-osorio
+  name: katerin-osorio
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: katerin-osorio
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000

--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - mariana-toro
   - jenny-florez
   - maria-fernanda-espana
+  - katerin-osorio


### PR DESCRIPTION
## Summary
- add the `katerin-osorio` client-site overlay from the homelab templates
- add basic auth credentials using the firstname/lastname convention: `katerin` / `osorio`
- register `katerin-osorio` in `apps/production/client-sites/kustomization.yaml`

## Verification
- `kubectl kustomize apps/production/client-sites`
- luloai-client-sites image build run #14 is still in progress at PR creation; deployment is pinned to expected CI tag `registry.yesidlopez.de/katerin-osorio:v1.0.14`