### PR TITLE
feat(client-sites): add veronica-mejia

### DIFF
--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - jenny-florez
   - maria-fernanda-espana
   - katerin-osorio
+  - veronica-mejia

--- a/apps/production/client-sites/veronica-mejia/basic-auth.yaml
+++ b/apps/production/client-sites/veronica-mejia/basic-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: veronica-mejia-basic-auth
+  namespace: lulo-demo-landings
+type: Opaque
+data:
+  auth: dmVyb25pY2E6JDJ5JDA1JEhFWVRKQ3Z1STFtYzd1L1BqMXI5VWViRnphZFNBai5pV1NVNkNOcjIvdUhsRGlKLjZscXNPCg==

--- a/apps/production/client-sites/veronica-mejia/deployment.yaml
+++ b/apps/production/client-sites/veronica-mejia/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+  labels:
+    app: veronica-mejia
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: veronica-mejia
+  template:
+    metadata:
+      labels:
+        app: veronica-mejia
+        name: veronica-mejia
+    spec:
+      containers:
+      - name: veronica-mejia
+        image: "registry.yesidlopez.de/veronica-mejia:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:veronica-mejia"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/veronica-mejia/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/veronica-mejia/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: veronica-mejia
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/veronica-mejia/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/veronica-mejia/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/veronica-mejia
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/veronica-mejia/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/veronica-mejia/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for veronica-mejia
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/veronica-mejia
+    strategy: Setters

--- a/apps/production/client-sites/veronica-mejia/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/veronica-mejia/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/veronica-mejia/ingress.yaml
+++ b/apps/production/client-sites/veronica-mejia/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: veronica-mejia-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "Demo Lulo AI"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - veronica-mejia.demo.luloai.com
+      secretName: veronica-mejia-tls
+  rules:
+    - host: veronica-mejia.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: veronica-mejia
+                port:
+                  number: 3000

--- a/apps/production/client-sites/veronica-mejia/kustomization.yaml
+++ b/apps/production/client-sites/veronica-mejia/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - basic-auth.yaml

--- a/apps/production/client-sites/veronica-mejia/service.yaml
+++ b/apps/production/client-sites/veronica-mejia/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: veronica-mejia
+  name: veronica-mejia
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: veronica-mejia
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000


### PR DESCRIPTION
Adds the first-time homelab demo overlay for veronica-mejia, including ingress, service/deployment, image automation, and basic auth.\n\nURL after merge/deploy: https://veronica-mejia.demo.luloai.com\nBasic auth: veronica / mejia\n\nValidated with:\n- kubectl kustomize apps/production/client-sites/veronica-mejia