### PR TITLE
Update Verónica Mejía demo image

### DIFF
--- a/apps/production/client-sites/veronica-mejia/deployment.yaml
+++ b/apps/production/client-sites/veronica-mejia/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: veronica-mejia
-        image: "registry.yesidlopez.de/veronica-mejia:v1.0.15" # {"$imagepolicy": "lulo-demo-landings:veronica-mejia"}
+        image: "registry.yesidlopez.de/veronica-mejia:v1.0.16" # {"$imagepolicy": "lulo-demo-landings:veronica-mejia"}
         ports:
         - containerPort: 3000
         env:


### PR DESCRIPTION
## Summary
- bumps the Verónica Mejía client-site deployment to registry.yesidlopez.de/veronica-mejia:v1.0.16

## Merge order
Merge after yesid-lopez/luloai-client-sites#7 has landed and the client-sites build has pushed v1.0.16.

## Verification
- kubectl kustomize apps/production/client-sites/veronica-mejia
- curl -sI -u veronica:mejia https://veronica-mejia.demo.luloai.com/ returned HTTP/2 200 for the current preview