### PR TITLE
feat(client-sites): add Catalina Rocha demo site

### DIFF
--- a/apps/production/client-sites/catalina-rocha/basic-auth.yaml
+++ b/apps/production/client-sites/catalina-rocha/basic-auth.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: catalina-rocha-basic-auth
+  namespace: lulo-demo-landings
+type: Opaque
+data:
+  auth: Y2F0YWxpbmE6JDJ5JDA1JHBZbExxdWh5OGJzeHpCTWxnOTFqZy5xRXlUVzZsVmxnaDZVSjNiYU9YeTBvWHFVUmRQZDBXCg==

--- a/apps/production/client-sites/catalina-rocha/deployment.yaml
+++ b/apps/production/client-sites/catalina-rocha/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+  labels:
+    app: catalina-rocha
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: catalina-rocha
+  template:
+    metadata:
+      labels:
+        app: catalina-rocha
+        name: catalina-rocha
+    spec:
+      containers:
+      - name: catalina-rocha
+        image: "registry.yesidlopez.de/catalina-rocha:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:catalina-rocha"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/catalina-rocha/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/catalina-rocha/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: catalina-rocha
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/catalina-rocha/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/catalina-rocha/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/catalina-rocha
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/catalina-rocha/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/catalina-rocha/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for catalina-rocha
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/catalina-rocha
+    strategy: Setters

--- a/apps/production/client-sites/catalina-rocha/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/catalina-rocha/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/catalina-rocha/ingress.yaml
+++ b/apps/production/client-sites/catalina-rocha/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: catalina-rocha-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: "Demo Lulo AI"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - catalina-rocha.demo.luloai.com
+      secretName: catalina-rocha-tls
+  rules:
+    - host: catalina-rocha.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: catalina-rocha
+                port:
+                  number: 3000

--- a/apps/production/client-sites/catalina-rocha/kustomization.yaml
+++ b/apps/production/client-sites/catalina-rocha/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - basic-auth.yaml

--- a/apps/production/client-sites/catalina-rocha/service.yaml
+++ b/apps/production/client-sites/catalina-rocha/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: catalina-rocha
+  name: catalina-rocha
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: catalina-rocha
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000

--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - maria-fernanda-espana
   - katerin-osorio
   - veronica-mejia
+  - catalina-rocha


### PR DESCRIPTION
## Summary
- add the catalina-rocha client-site overlay
- register it in the client-sites parent kustomization
- generate basic auth credentials using the first-name/last-name convention

## Verification
- kubectl kustomize apps/production/client-sites