### PR TITLE
fix: resize existing Prometheus PVC

### DIFF
--- a/infrastructure/controllers/prometheus/kustomization.yaml
+++ b/infrastructure/controllers/prometheus/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - helmrepository.yaml
   - helmrelease.yaml
   - configmap-helm-values.yaml
+  - prometheus-pvc-resize.yaml
   - alerts/

--- a/infrastructure/controllers/prometheus/prometheus-pvc-resize.yaml
+++ b/infrastructure/controllers/prometheus/prometheus-pvc-resize.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0
+  namespace: prometheus
+  annotations:
+    # This manifest exists only to resize the already-created PVC from 30Gi to 50Gi.
+    # The PVC is created by the Prometheus StatefulSet volumeClaimTemplate, but
+    # changes to that template do not resize existing claims automatically.
+    kustomize.toolkit.fluxcd.io/prune: disabled
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: longhorn
+  volumeMode: Filesystem


### PR DESCRIPTION
## Problem
The Longhorn volume usage alert is still firing after PR #121.

PR #121 increased the Prometheus storage template from 30Gi to 50Gi, and Flux applied it successfully:
- ConfigMap values now render storage: 50Gi
- Prometheus CR storageSpec now reports 50Gi
- StatefulSet volumeClaimTemplate now reports 50Gi

However, the already-created PVC still reports 30Gi:
- PVC: prometheus/prometheus-kube-prometheus-stack-prometheus-db-prometheus-kube-prometheus-stack-prometheus-0
- Current PVC request/capacity: 30Gi
- Longhorn volume size: 30Gi
- Longhorn actual size: ~41.9GB, above the provisioned 30Gi

## Root cause
Kubernetes does not automatically resize existing PVCs created from a StatefulSet volumeClaimTemplate when the template changes. The new 50Gi value only applies to newly-created claims; the existing Prometheus PVC remains at 30Gi unless patched directly.

## Fix
Add a GitOps-managed PersistentVolumeClaim manifest for the existing Prometheus PVC with storage: 50Gi.

This allows Flux to patch the existing PVC request, triggering Longhorn volume expansion. The manifest includes prune: disabled so Flux will not delete the PVC if this temporary resize manifest is removed later.
