### PR TITLE
chore(multica): bump backend and frontend to v0.3.10

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -10,7 +10,7 @@ data:
     backend:
       replicaCount: 1
       image:
-        tag: v0.3.7
+        tag: v0.3.10
       resources:
         requests:
           cpu: 100m
@@ -53,7 +53,7 @@ data:
     frontend:
       replicaCount: 1
       image:
-        tag: v0.3.7
+        tag: v0.3.10
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary
- Bump `multica` backend and frontend image tags from `v0.3.7` to `v0.3.10` in `apps/production/multica/configmap-helm-values.yaml`.
- Goal: unblock the stuck `multica/multica` HelmRelease upgrade (currently failing for 2d+).

## Context
The `v0.3.7` rollout never reached `Ready`:
- **Frontend (v0.3.7)** → `ImagePullBackOff` — `ghcr.io/multica-ai/multica-web:v0.3.7` could not be pulled.
- **Backend (v0.3.7)** → `CrashLoopBackOff` (596 restarts). Failed at migration `103_drop_legacy_daily_rollups`:
  ```
  refusing to drop legacy daily rollups: task_usage_hourly_rollup_state.watermark_at
  (1970-01-01) trails task_usage latest event (2026-05-27) by more than 01:00:00
  — backfill is incomplete or pg_cron is not running.
  ```
  The guard is intentional (`cmd/backfill_task_usage_hourly`). **If `v0.3.10` does not change this migration logic, the backend will still crash after this bump until the backfill is run and/or `pg_cron` is verified.**

The old `v0.3.7` pods are still serving traffic, so there is no immediate outage — but the HelmRelease keeps reporting `Ready: False`.

## Test plan
- [ ] Confirm `ghcr.io/multica-ai/multica-backend:v0.3.10` and `ghcr.io/multica-ai/multica-web:v0.3.10` are published and pullable from the cluster.
- [ ] Verify whether `v0.3.10` either ships the rollup backfill fix OR run `cmd/backfill_task_usage_hourly` before merge.
- [ ] Check `pg_cron` jobs are active on `multica-postgres-1`.
- [ ] After merge: `flux reconcile helmrelease multica -n multica --with-source` and confirm pods reach `Ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)