### PR TITLE
feat(multica): schedule task_usage hourly rollup via CronJob

### DIFF
--- a/apps/production/multica/cronjob-task-usage-rollup.yaml
+++ b/apps/production/multica/cronjob-task-usage-rollup.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: multica-task-usage-rollup
+  namespace: multica
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      ttlSecondsAfterFinished: 3600
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: rollup
+              image: ghcr.io/cloudnative-pg/postgresql:17.6-standard-trixie
+              command:
+                - psql
+                - -v
+                - ON_ERROR_STOP=1
+                - -c
+                - SELECT rollup_task_usage_hourly();
+              env:
+                - name: PGHOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: multica-postgres-app
+                      key: host
+                - name: PGPORT
+                  valueFrom:
+                    secretKeyRef:
+                      name: multica-postgres-app
+                      key: port
+                - name: PGUSER
+                  valueFrom:
+                    secretKeyRef:
+                      name: multica-postgres-app
+                      key: user
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: multica-postgres-app
+                      key: password
+                - name: PGDATABASE
+                  valueFrom:
+                    secretKeyRef:
+                      name: multica-postgres-app
+                      key: dbname
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 200m
+                  memory: 128Mi

--- a/apps/production/multica/kustomization.yaml
+++ b/apps/production/multica/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - postgres-cluster.yaml
   - sealed-multica-app-secrets.yaml
   - sealed-minio-backup-credentials.yaml
+  - cronjob-task-usage-rollup.yaml


### PR DESCRIPTION
## Summary

- Adds `cronjob-task-usage-rollup.yaml`: a 5-minute K8s CronJob that calls `SELECT rollup_task_usage_hourly()` on `multica-postgres-rw`. Idempotent and watermark-driven.
- Registers the CronJob in `apps/production/multica/kustomization.yaml`.

## Why

[LUL-127](https://multica.ai) — Multica `v0.3.10` backend stuck in `CrashLoopBackOff` because migration `103` (drop legacy daily rollups) refuses to run while `task_usage_hourly_rollup_state.watermark_at` is at `1970-01-01`. The bundled CNPG image (`ghcr.io/cloudnative-pg/postgresql:17.6-standard-trixie`) does **not** ship `pg_cron`, so nothing was calling `rollup_task_usage_hourly()` and the dashboard's hourly aggregate never got populated.

This is the upstream-recommended **Option A** from [`SELF_HOSTING.md`](https://github.com/multica-ai/multica/blob/main/SELF_HOSTING.md#option-a--external-cron--systemd-timer-simplest) — simpler than swapping the Postgres image to one with `pg_cron`, and keeps us on the stock CNPG image we already use elsewhere.

## Out of scope (manual, runbook-only)

The one-shot historical backfill is **not** in git (one-time op, would just sit there as dead Flux state):

```bash
kubectl -n multica exec multica-backend-5745c549f6-tzdpq -- \
  ./backfill_task_usage_hourly --sleep-between-slices=2s
```

Run this **before** the next backend upgrade attempt. Once the CronJob is steady-state, the watermark stays current and migration 103 will pass.

## Test plan

- [ ] `kustomize build apps/production/multica` renders cleanly (verified locally).
- [ ] After merge, Flux reconciles and the CronJob appears: `kubectl -n multica get cronjob multica-task-usage-rollup`.
- [ ] First scheduled run succeeds: `kubectl -n multica get jobs -l job-name | head` and check pod logs for `rollup_task_usage_hourly`.
- [ ] Run the manual backfill (command above), then `flux reconcile helmrelease multica -n multica --with-source` and confirm the v0.3.10 backend pod goes `Ready`.
- [ ] Confirm watermark stays current after a few CronJob ticks:
  `kubectl -n multica exec multica-postgres-1 -c postgres -- psql -U postgres -d multica -c "SELECT watermark_at FROM task_usage_hourly_rollup_state;"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)