### PR TITLE
feat(client-sites): add LUL-130 Juanita Gomez infra

### DIFF
--- a/apps/production/client-sites/juanita-gomez/deployment.yaml
+++ b/apps/production/client-sites/juanita-gomez/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+  labels:
+    app: juanita-gomez
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: juanita-gomez
+  template:
+    metadata:
+      labels:
+        app: juanita-gomez
+        name: juanita-gomez
+    spec:
+      containers:
+      - name: juanita-gomez
+        image: "registry.yesidlopez.de/juanita-gomez:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:juanita-gomez"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        - name: NEXT_PUBLIC_UMAMI_SCRIPT_URL
+          value: "https://umami.yesidlopez.de/script.js"
+        - name: NEXT_PUBLIC_UMAMI_WEBSITE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: lulo-demo-preview-config
+              key: umamiWebsiteId
+        - name: DISCORD_DEMO_OPEN_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: lulo-demo-preview-webhook
+              key: webhookUrl
+              optional: true
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/juanita-gomez/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/juanita-gomez/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: juanita-gomez
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/juanita-gomez/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/juanita-gomez/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/juanita-gomez
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/juanita-gomez/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/juanita-gomez/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for juanita-gomez
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/juanita-gomez
+    strategy: Setters

--- a/apps/production/client-sites/juanita-gomez/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/juanita-gomez/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/juanita-gomez/ingress.yaml
+++ b/apps/production/client-sites/juanita-gomez/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - juanita-gomez.demo.luloai.com
+      secretName: juanita-gomez-tls
+  rules:
+    - host: juanita-gomez.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: juanita-gomez
+                port:
+                  number: 3000

--- a/apps/production/client-sites/juanita-gomez/kustomization.yaml
+++ b/apps/production/client-sites/juanita-gomez/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/production/client-sites/juanita-gomez/service.yaml
+++ b/apps/production/client-sites/juanita-gomez/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: juanita-gomez
+  name: juanita-gomez
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: juanita-gomez
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000

--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - veronica-mejia
   - catalina-rocha
   - psicmariaqm
+  - juanita-gomez


### PR DESCRIPTION
## Summary
- Add the `juanita-gomez` client-site overlay under `apps/production/client-sites`.
- Configure deployment, service, ingress for `juanita-gomez.demo.luloai.com`, and Flux image automation for `registry.yesidlopez.de/juanita-gomez`.
- Register the new overlay in the shared client-sites kustomization.

## Test plan
- `kubectl kustomize apps/production/client-sites`


Made with [Cursor](https://cursor.com)