### PR TITLE
LUL-135: Add Jim Ballester homelab site

### DIFF
--- a/apps/production/client-sites/jim-ballester/deployment.yaml
+++ b/apps/production/client-sites/jim-ballester/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jim-ballester
+  namespace: lulo-demo-landings
+  labels:
+    app: jim-ballester
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jim-ballester
+  template:
+    metadata:
+      labels:
+        app: jim-ballester
+        name: jim-ballester
+    spec:
+      containers:
+      - name: jim-ballester
+        image: "registry.yesidlopez.de/jim-ballester:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:jim-ballester"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        - name: NEXT_PUBLIC_UMAMI_SCRIPT_URL
+          value: "https://umami.yesidlopez.de/script.js"
+        - name: NEXT_PUBLIC_UMAMI_WEBSITE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: lulo-demo-preview-config
+              key: umamiWebsiteId
+        - name: DISCORD_DEMO_OPEN_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: lulo-demo-preview-webhook
+              key: webhookUrl
+              optional: true
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/jim-ballester/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/jim-ballester/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: jim-ballester
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: jim-ballester
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/jim-ballester/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/jim-ballester/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: jim-ballester
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/jim-ballester
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/jim-ballester/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/jim-ballester/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: jim-ballester
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for jim-ballester
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/jim-ballester
+    strategy: Setters

--- a/apps/production/client-sites/jim-ballester/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/jim-ballester/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/jim-ballester/ingress.yaml
+++ b/apps/production/client-sites/jim-ballester/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jim-ballester
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - jim-ballester.demo.luloai.com
+      secretName: jim-ballester-tls
+  rules:
+    - host: jim-ballester.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jim-ballester
+                port:
+                  number: 3000

--- a/apps/production/client-sites/jim-ballester/kustomization.yaml
+++ b/apps/production/client-sites/jim-ballester/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/production/client-sites/jim-ballester/service.yaml
+++ b/apps/production/client-sites/jim-ballester/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: jim-ballester
+  name: jim-ballester
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: jim-ballester
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000

--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -18,3 +18,4 @@ resources:
   - catalina-rocha
   - psicmariaqm
   - juanita-gomez
+  - jim-ballester


### PR DESCRIPTION
## Summary
- adds the jim-ballester client-site overlay under apps/production/client-sites
- registers jim-ballester in the parent client-sites kustomization
- includes Flux image automation for registry.yesidlopez.de/jim-ballester

Reference: yesid-lopez/luloai-client-sites#14

## Validation
- kubectl kustomize apps/production/client-sites