### PR TITLE
LUL-138: add Laura Galeano demo site

### DIFF
--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - psicmariaqm
   - juanita-gomez
   - jim-ballester
+  - laura-galeano-psicologa

--- a/apps/production/client-sites/laura-galeano-psicologa/deployment.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+  labels:
+    app: laura-galeano-psicologa
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: laura-galeano-psicologa
+  template:
+    metadata:
+      labels:
+        app: laura-galeano-psicologa
+        name: laura-galeano-psicologa
+    spec:
+      containers:
+      - name: laura-galeano-psicologa
+        image: "registry.yesidlopez.de/laura-galeano-psicologa:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:laura-galeano-psicologa"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        - name: NEXT_PUBLIC_UMAMI_SCRIPT_URL
+          value: "https://umami.yesidlopez.de/script.js"
+        - name: NEXT_PUBLIC_UMAMI_WEBSITE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: lulo-demo-preview-config
+              key: umamiWebsiteId
+        - name: DISCORD_DEMO_OPEN_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: lulo-demo-preview-webhook
+              key: webhookUrl
+              optional: true
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/laura-galeano-psicologa/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: laura-galeano-psicologa
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/laura-galeano-psicologa/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/laura-galeano-psicologa
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/laura-galeano-psicologa/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for laura-galeano-psicologa
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/laura-galeano-psicologa
+    strategy: Setters

--- a/apps/production/client-sites/laura-galeano-psicologa/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/laura-galeano-psicologa/ingress.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - laura-galeano-psicologa.demo.luloai.com
+      secretName: laura-galeano-psicologa-tls
+  rules:
+    - host: laura-galeano-psicologa.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: laura-galeano-psicologa
+                port:
+                  number: 3000

--- a/apps/production/client-sites/laura-galeano-psicologa/kustomization.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/production/client-sites/laura-galeano-psicologa/service.yaml
+++ b/apps/production/client-sites/laura-galeano-psicologa/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: laura-galeano-psicologa
+  name: laura-galeano-psicologa
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: laura-galeano-psicologa
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000


### PR DESCRIPTION
## Summary
- Adds the `laura-galeano-psicologa` demo landing overlay under `apps/production/client-sites/`.
- Registers the site in the parent `client-sites` kustomization.
- Provisions the readable demo host `laura-galeano-psicologa.demo.luloai.com` using the existing client-site templates.

## Dependency
- Source landing PR: https://github.com/yesid-lopez/luloai-client-sites/pull/16
- Merge this after the landing image is built and available in the registry.

## Validation
- `kubectl kustomize apps/production/client-sites/laura-galeano-psicologa`
- `kubectl kustomize apps/production/client-sites`

## Screenshots
Desktop:
![Desktop screenshot](https://raw.githubusercontent.com/yesid-lopez/luloai-client-sites/a29b2ecaa66a832e1410e3e7d1b5c9b67aa0bb60/sites/laura-galeano-psicologa/screenshots/desktop.png)

Mobile:
![Mobile screenshot](https://raw.githubusercontent.com/yesid-lopez/luloai-client-sites/a29b2ecaa66a832e1410e3e7d1b5c9b67aa0bb60/sites/laura-galeano-psicologa/screenshots/mobile.png)
