### PR TITLE
fix: disable jim ballester deployment

### DIFF
--- a/apps/production/client-sites/jim-ballester/deployment.yaml
+++ b/apps/production/client-sites/jim-ballester/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: jim-ballester
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: jim-ballester


### PR DESCRIPTION
## Problem
The jim-ballester demo deployment is currently running one replica in the lulo-demo-landings namespace.

## Root cause
The Deployment manifest declares replicas: 1, so Flux keeps one pod running.

## Fix
Set apps/production/client-sites/jim-ballester/deployment.yaml replicas to 0. After merge and Flux reconciliation, the Deployment remains declared but no pod is scheduled.

Note: I found the live resource as jim-ballester, not janne-ballester.