### PR TITLE
fix: update multica images to 0.3.11

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -10,7 +10,7 @@ data:
     backend:
       replicaCount: 1
       image:
-        tag: v0.3.10
+        tag: v0.3.11
       resources:
         requests:
           cpu: 100m
@@ -53,7 +53,7 @@ data:
     frontend:
       replicaCount: 1
       image:
-        tag: v0.3.10
+        tag: v0.3.11
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Problem
Multica needs to run the latest application image release.

## Root cause
The Helm values override still pinned both backend and frontend images to `v0.3.10`.

## Fix
Updated both Multica backend and frontend image tags to `v0.3.11` in `apps/production/multica/configmap-helm-values.yaml`.

Validation: `kubectl kustomize apps/production/multica`.