### PR TITLE
chore(renovate): auto-update multica backend/frontend image tags

### DIFF
--- a/apps/production/multica/configmap-helm-values.yaml
+++ b/apps/production/multica/configmap-helm-values.yaml
@@ -10,6 +10,7 @@ data:
     backend:
       replicaCount: 1
       image:
+        # renovate: datasource=docker depName=ghcr.io/multica-ai/multica-backend
         tag: v0.3.11
       resources:
         requests:
@@ -53,6 +54,7 @@ data:
     frontend:
       replicaCount: 1
       image:
+        # renovate: datasource=docker depName=ghcr.io/multica-ai/multica-web
         tag: v0.3.11
       resources:
         requests:

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,29 @@
       "/\\.yaml$/"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track image tags pinned inside Helm values ConfigMaps (e.g. multica backend/frontend)",
+      "managerFilePatterns": [
+        "/configmap-helm-values\\.yaml$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)\\s*\\n\\s*tag:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ],
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
+    {
+      "description": "Bump multica backend + frontend together (released from one monorepo tag)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "ghcr.io/multica-ai/multica-backend",
+        "ghcr.io/multica-ai/multica-web"
+      ],
+      "groupName": "multica images"
+    },
     {
       "description": "Group infrastructure controller updates",
       "matchFileNames": ["infrastructure/**"],


### PR DESCRIPTION
## Problema
Renovate no actualizaba las imágenes de multica (`#138` se hizo a mano), mientras umami/infra sí se actualizan solos. Causa: los tags viven dentro del bloque `values.yaml` de un ConfigMap como `tag: v0.3.11` **sin el repositorio**, así que Renovate no sabe a qué imagen corresponden.

## Cambio
- `# renovate:` annotations sobre cada `tag:` en `configmap-helm-values.yaml` indicando `datasource=docker` + `depName`.
- `customManager` (regex) en `renovate.json` que lee esas anotaciones en cualquier `configmap-helm-values.yaml` (reutilizable para otras apps con tags embebidos).
- `packageRule` que agrupa `multica-backend` + `multica-web` en un solo PR ("multica images"), ya que se publican juntos.

## Efecto
A partir de ahora Renovate abrirá PR cuando salga `v0.3.12`+, como con umami. **Sin cambio funcional**: los tags siguen en `v0.3.11`, no toca el cluster ni los datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)