### PR TITLE
feat(client-sites): add LUL-134 camila-duque demo

### DIFF
--- a/apps/production/client-sites/camila-duque/deployment.yaml
+++ b/apps/production/client-sites/camila-duque/deployment.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: camila-duque
+  namespace: lulo-demo-landings
+  labels:
+    app: camila-duque
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camila-duque
+  template:
+    metadata:
+      labels:
+        app: camila-duque
+        name: camila-duque
+    spec:
+      containers:
+      - name: camila-duque
+        image: "registry.yesidlopez.de/camila-duque:v0.0.1" # {"$imagepolicy": "lulo-demo-landings:camila-duque"}
+        ports:
+        - containerPort: 3000
+        env:
+        - name: NODE_ENV
+          value: "production"
+        - name: PORT
+          value: "3000"
+        - name: HOSTNAME
+          value: "0.0.0.0"
+        - name: NEXT_PUBLIC_UMAMI_SCRIPT_URL
+          value: "https://umami.yesidlopez.de/script.js"
+        - name: NEXT_PUBLIC_UMAMI_WEBSITE_ID
+          valueFrom:
+            configMapKeyRef:
+              name: lulo-demo-preview-config
+              key: umamiWebsiteId
+        - name: DISCORD_DEMO_OPEN_WEBHOOK_URL
+          valueFrom:
+            secretKeyRef:
+              name: lulo-demo-preview-webhook
+              key: webhookUrl
+              optional: true
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 3000
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "300m"
+      imagePullSecrets:
+        - name: registry-secret

--- a/apps/production/client-sites/camila-duque/image-automation/imagepolicy.yaml
+++ b/apps/production/client-sites/camila-duque/image-automation/imagepolicy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: camila-duque
+  namespace: lulo-demo-landings
+spec:
+  imageRepositoryRef:
+    name: camila-duque
+  policy:
+    semver:
+      range: ">=0.0.0"
+  filterTags:
+    pattern: '^v?[0-9]+\.[0-9]+\.[0-9]+$'
+    extract: '$0'

--- a/apps/production/client-sites/camila-duque/image-automation/imagerepository.yaml
+++ b/apps/production/client-sites/camila-duque/image-automation/imagerepository.yaml
@@ -1,0 +1,10 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageRepository
+metadata:
+  name: camila-duque
+  namespace: lulo-demo-landings
+spec:
+  image: registry.yesidlopez.de/camila-duque
+  interval: 1m
+  secretRef:
+    name: registry-secret

--- a/apps/production/client-sites/camila-duque/image-automation/imageupdateautomation.yaml
+++ b/apps/production/client-sites/camila-duque/image-automation/imageupdateautomation.yaml
@@ -1,0 +1,43 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImageUpdateAutomation
+metadata:
+  name: camila-duque
+  namespace: lulo-demo-landings
+spec:
+  interval: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  git:
+    checkout:
+      ref:
+        branch: main
+    commit:
+      author:
+        email: fluxcdbot@users.noreply.github.com
+        name: fluxcdbot
+      messageTemplate: |
+        Automated image update for camila-duque
+
+        Automation name: {{ .AutomationObject }}
+
+        Files:
+        {{ range $filename, $_ := .Changed.FileChanges -}}
+        - {{ $filename }}
+        {{ end -}}
+
+        Objects:
+        {{ range $resource, $_ := .Changed.Objects -}}
+        - {{ $resource.Kind }} {{ $resource.Name }}
+        {{ end -}}
+
+        Images:
+        {{ range .Changed.Changes -}}
+        - {{.NewValue}}
+        {{ end -}}
+    push:
+      branch: main
+  update:
+    path: ./apps/production/client-sites/camila-duque
+    strategy: Setters

--- a/apps/production/client-sites/camila-duque/image-automation/kustomization.yaml
+++ b/apps/production/client-sites/camila-duque/image-automation/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - imagerepository.yaml
+  - imagepolicy.yaml
+  - imageupdateautomation.yaml

--- a/apps/production/client-sites/camila-duque/ingress.yaml
+++ b/apps/production/client-sites/camila-duque/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: camila-duque
+  namespace: lulo-demo-landings
+  annotations:
+    cert-manager.io/cluster-issuer: luloai-issuer
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    external-dns.alpha.kubernetes.io/target: homelab.luloai.com
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - camila-duque.demo.luloai.com
+      secretName: camila-duque-tls
+  rules:
+    - host: camila-duque.demo.luloai.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: camila-duque
+                port:
+                  number: 3000

--- a/apps/production/client-sites/camila-duque/kustomization.yaml
+++ b/apps/production/client-sites/camila-duque/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Per-client resources only. The shared namespace and registry-secret live
+# one level up in apps/production/client-sites/.
+resources:
+  - image-automation
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/apps/production/client-sites/camila-duque/service.yaml
+++ b/apps/production/client-sites/camila-duque/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: camila-duque
+  name: camila-duque
+  namespace: lulo-demo-landings
+spec:
+  selector:
+    app: camila-duque
+  type: ClusterIP
+  ports:
+    - port: 3000
+      protocol: TCP
+      targetPort: 3000

--- a/apps/production/client-sites/kustomization.yaml
+++ b/apps/production/client-sites/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - juanita-gomez
   - jim-ballester
   - laura-galeano-psicologa
+  - camila-duque


### PR DESCRIPTION
## Related Multica issue
- LUL-134 / Multica issue `4e40b952-8411-4afa-af48-93d3263cb98e`

## Companion PR
- Client landing source: https://github.com/yesid-lopez/luloai-client-sites/pull/17

## Summary
- Adds the `camila-duque` client demo overlay under `apps/production/client-sites/`.
- Registers `camila-duque.demo.luloai.com` in the parent client-sites kustomization.
- Includes Flux image repository, image policy, and image update automation for `registry.yesidlopez.de/camila-duque`.
- Starts the deployment on the published multi-arch image `registry.yesidlopez.de/camila-duque:v1.0.29` from the merged client-sites PR.

## Verification
- `kubectl kustomize apps/production/client-sites/camila-duque`
- `kubectl kustomize apps/production/client-sites`
- Client-sites image workflow succeeded: https://github.com/yesid-lopez/luloai-client-sites/actions/runs/26719968217
